### PR TITLE
graph: add feature fp apis inside graph library

### DIFF
--- a/app/graph/commands.list
+++ b/app/graph/commands.list
@@ -31,3 +31,9 @@ help ipv6_lookup                                         # Print help on ipv6_lo
 neigh add ipv4 <IPv4>ip <STRING>mac                      # Add static neighbour for IPv4
 neigh add ipv6 <IPv6>ip <STRING>mac                      # Add static neighbour for IPv6
 help neigh                                               # Print help on neigh commands
+
+feature arcs                                             # show all feature arcs
+feature <STRING>name show                                # Show feature arc details
+feature enable <STRING>arc_name <STRING>feature_name <UINT16>interface   # Enable feature on interface
+feature disable <STRING>arc_name <STRING>feature_name <UINT16>interface  # Disable feature on interface
+help feature                                             # Print help on feature command

--- a/app/graph/feature.c
+++ b/app/graph/feature.c
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <cmdline_parse.h>
+#include <cmdline_parse_num.h>
+#include <cmdline_parse_string.h>
+#include <cmdline_socket.h>
+#include <rte_ethdev.h>
+
+#include "module_api.h"
+
+static const char
+cmd_feature_arcs_help[] = "feature arcs    # Display all feature arcs";
+
+static const char
+cmd_feature_show_help[] = "feature <arc_name> show   # Display features within an arc";
+
+static const char
+cmd_feature_enable_help[] = "feature enable <arc name> <feature name> <port-id>";
+
+static const char
+cmd_feature_disable_help[] = "feature disable <arc name> <feature name> <port-id>";
+
+static void
+feature_show(const char *arc_name)
+{
+	rte_graph_feature_arc_t _arc;
+	uint32_t length, count, i;
+
+	length = strlen(conn->msg_out);
+	conn->msg_out += length;
+
+	if (rte_graph_feature_arc_lookup_by_name(arc_name, &_arc) < 0)
+		return;
+
+	count = rte_graph_feature_arc_num_features(_arc);
+
+	if (count) {
+		snprintf(conn->msg_out, conn->msg_out_len_max, "\n%s%s%s\n",
+			 "----------------------------- feature arc: ",
+			 rte_graph_feature_arc_get(_arc)->feature_arc_name,
+			 " -----------------------------");
+		for (i = 0; i < count; i++)
+			snprintf(conn->msg_out + strlen(conn->msg_out),
+				 conn->msg_out_len_max, "%s\n",
+				 rte_graph_feature_arc_feature_to_name(_arc, i));
+	}
+	length = strlen(conn->msg_out);
+	conn->msg_out_len_max -= length;
+}
+
+static void
+feature_arcs_show(void)
+{
+	uint32_t length, count, i;
+	char **names;
+
+	length = strlen(conn->msg_out);
+	conn->msg_out += length;
+
+	count = rte_graph_feature_arc_names_get(NULL);
+
+	if (count) {
+		names = malloc(count);
+		if (!names) {
+			snprintf(conn->msg_out, conn->msg_out_len_max, "Failed to allocate memory\n");
+			return;
+		}
+		count = rte_graph_feature_arc_names_get(names);
+		snprintf(conn->msg_out, conn->msg_out_len_max, "\n%s\n",
+			 "----------------------------- feature arcs -----------------------------");
+		for (i = 0; i < count; i++)
+			feature_show(names[i]);
+		free(names);
+	}
+	length = strlen(conn->msg_out);
+	conn->msg_out_len_max -= length;
+}
+
+void
+cmd_feature_parsed(void *parsed_result, __rte_unused struct cmdline *cl,
+		   __rte_unused void *data)
+{
+	struct cmd_feature_result *res = parsed_result;
+
+	feature_show(res->name);
+}
+
+
+void
+cmd_feature_arcs_parsed(__rte_unused void *parsed_result, __rte_unused struct cmdline *cl,
+			__rte_unused void *data)
+{
+		feature_arcs_show();
+}
+
+void
+cmd_feature_enable_parsed(void *parsed_result, __rte_unused struct cmdline *cl,
+			  __rte_unused void *data)
+{
+	struct cmd_feature_enable_result *res = parsed_result;
+	rte_graph_feature_arc_t arc;
+
+	if (!rte_graph_feature_arc_lookup_by_name(res->arc_name, &arc))
+		rte_graph_feature_enable(arc, res->interface, res->feature_name,
+					 res->interface, NULL);
+}
+
+void
+cmd_feature_disable_parsed(void *parsed_result, __rte_unused struct cmdline *cl,
+			   __rte_unused void *data)
+{
+	struct cmd_feature_disable_result *res = parsed_result;
+	rte_graph_feature_arc_t arc;
+
+	if (!rte_graph_feature_arc_lookup_by_name(res->arc_name, &arc))
+		rte_graph_feature_disable(arc, res->interface, res->feature_name, NULL);
+
+}
+
+void
+cmd_help_feature_parsed(__rte_unused void *parsed_result, __rte_unused struct cmdline *cl,
+			__rte_unused void *data)
+{
+	size_t len;
+
+	len = strlen(conn->msg_out);
+	conn->msg_out += len;
+	snprintf(conn->msg_out, conn->msg_out_len_max, "\n%s\n%s\n%s\n%s\n%s\n",
+		 "----------------------------- feature command help -----------------------------",
+		 cmd_feature_arcs_help, cmd_feature_show_help, cmd_feature_enable_help,
+		 cmd_feature_disable_help);
+
+	len = strlen(conn->msg_out);
+	conn->msg_out_len_max -= len;
+}

--- a/app/graph/feature.h
+++ b/app/graph/feature.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+
+#ifndef APP_GRAPH_FEATURE_H
+#define APP_GRAPH_FEATURE_H
+
+#include <cmdline_parse.h>
+#include <rte_graph_feature_arc_worker.h>
+
+int feature_enable(const char *arc_name, const char *feature_name, uint16_t portid);
+int feature_disable(const char *arc_name, const char *feature_name, uint16_t portid);
+#endif

--- a/app/graph/graph.c
+++ b/app/graph/graph.c
@@ -12,6 +12,7 @@
 #include <cmdline_socket.h>
 #include <rte_ethdev.h>
 #include <rte_graph_worker.h>
+#include <rte_graph_feature_arc_worker.h>
 #include <rte_log.h>
 
 #include "graph_priv.h"
@@ -264,6 +265,9 @@ cmd_graph_start_parsed(__rte_unused void *parsed_result, __rte_unused struct cmd
 	struct rte_node_ethdev_config *conf;
 	uint32_t nb_graphs = 0, nb_conf, i;
 	int rc = -EINVAL;
+
+	if (app_graph_feature_arc_enabled())
+		rte_graph_feature_arc_init();
 
 	conf = graph_rxtx_node_config_get(&nb_conf, &nb_graphs);
 	for (i = 0; i < MAX_GRAPH_USECASES; i++) {

--- a/app/graph/graph.c
+++ b/app/graph/graph.c
@@ -266,9 +266,6 @@ cmd_graph_start_parsed(__rte_unused void *parsed_result, __rte_unused struct cmd
 	uint32_t nb_graphs = 0, nb_conf, i;
 	int rc = -EINVAL;
 
-	if (app_graph_feature_arc_enabled())
-		rte_graph_feature_arc_init();
-
 	conf = graph_rxtx_node_config_get(&nb_conf, &nb_graphs);
 	for (i = 0; i < MAX_GRAPH_USECASES; i++) {
 		if (!strcmp(graph_config.usecases[i].name, "l3fwd")) {

--- a/app/graph/ip4_output_hook.c
+++ b/app/graph/ip4_output_hook.c
@@ -42,54 +42,12 @@ static __rte_always_inline uint16_t
 __app_graph_ip4_output_hook_node_process(struct rte_graph *graph, struct rte_node *node,
 					 void **objs, uint16_t nb_objs)
 {
-	struct rte_graph_feature_arc *arc =
-		rte_graph_feature_arc_get(OUTPUT_HOOK_FEATURE_ARC(node->ctx));
-	int feat_dyn_off = rte_graph_feature_arc_mbuf_dynfield_offset_get();
-	struct rte_graph_feature_arc_mbuf_dynfields *mbfields = NULL;
-	void **to_next, **from;
-	uint16_t last_spec = 0;
-	rte_edge_t next_index;
-	struct rte_mbuf *mbuf;
-	uint16_t held = 0;
-	uint16_t next;
-	int i;
+	RTE_SET_USED(objs);
 
-	/* Speculative next */
-	next_index = OUTPUT_HOOK_LAST_NEXT_INDEX(node->ctx);
-
-	from = objs;
-	to_next = rte_node_next_stream_get(graph, node, next_index, nb_objs);
-	for (i = 0; i < nb_objs; i++) {
-
-		mbuf = (struct rte_mbuf *)objs[i];
-
-		/* Send mbuf to next enabled feature */
-		mbfields = rte_graph_feature_arc_mbuf_dynfields_get(mbuf, feat_dyn_off);
-		rte_graph_feature_data_next_feature_get(arc, &mbfields->feature_data, &next);
-
-		if (unlikely(next_index != next)) {
-			/* Copy things successfully speculated till now */
-			rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
-			from += last_spec;
-			to_next += last_spec;
-			held += last_spec;
-			last_spec = 0;
-
-			rte_node_enqueue_x1(graph, node, next, from[0]);
-			from += 1;
-		} else {
-			last_spec += 1;
-		}
-	}
-	/* !!! Home run !!! */
-	if (likely(last_spec == nb_objs)) {
-		rte_node_next_stream_move(graph, node, next_index);
-		return nb_objs;
-	}
-	held += last_spec;
-	rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
-	rte_node_next_stream_put(graph, node, next_index, held);
-	OUTPUT_HOOK_LAST_NEXT_INDEX(node->ctx) = next;
+	rte_node_next_stream_get(graph, node,
+				 0 /* original next_node is at index 0*/,
+				 nb_objs);
+	rte_node_next_stream_move(graph, node, 0);
 
 	return nb_objs;
 }

--- a/app/graph/ip4_output_hook.c
+++ b/app/graph/ip4_output_hook.c
@@ -1,0 +1,168 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+
+#include <rte_graph.h>
+#include <rte_graph_worker.h>
+#include <rte_graph_feature_arc_worker.h>
+
+#include "rte_node_ip4_api.h"
+
+#define IP4_OUTPUT_HOOK_FEATURE1_NAME "app_ip4_out_feat1"
+#define IP4_OUTPUT_HOOK_FEATURE2_NAME "app_ip4_out_feat2"
+
+struct output_hook_node_ctx {
+	rte_graph_feature_arc_t out_arc;
+	uint16_t last_index;
+};
+
+#define OUTPUT_HOOK_FEATURE_ARC(ctx) \
+	(((struct output_hook_node_ctx *)ctx)->out_arc)
+
+#define OUTPUT_HOOK_LAST_NEXT_INDEX(ctx) \
+	(((struct output_hook_node_ctx *)ctx)->last_index)
+
+static int
+__app_graph_ip4_output_hook_node_init(const struct rte_graph *graph, struct rte_node *node)
+{
+	rte_graph_feature_arc_t feature;
+
+	RTE_SET_USED(graph);
+
+	rte_graph_feature_arc_lookup_by_name(RTE_IP4_OUTPUT_FEATURE_ARC_NAME, &feature);
+
+	OUTPUT_HOOK_FEATURE_ARC(node->ctx) = feature;
+	/* pkt_drop */
+	OUTPUT_HOOK_LAST_NEXT_INDEX(node->ctx) = 0;
+
+	return 0;
+}
+
+static __rte_always_inline uint16_t
+__app_graph_ip4_output_hook_node_process(struct rte_graph *graph, struct rte_node *node,
+					 void **objs, uint16_t nb_objs)
+{
+	struct rte_graph_feature_arc *arc =
+		rte_graph_feature_arc_get(OUTPUT_HOOK_FEATURE_ARC(node->ctx));
+	int feat_dyn_off = rte_graph_feature_arc_mbuf_dynfield_offset_get();
+	struct rte_graph_feature_arc_mbuf_dynfields *mbfields = NULL;
+	void **to_next, **from;
+	uint16_t last_spec = 0;
+	rte_edge_t next_index;
+	struct rte_mbuf *mbuf;
+	uint16_t held = 0;
+	uint16_t next;
+	int i;
+
+	/* Speculative next */
+	next_index = OUTPUT_HOOK_LAST_NEXT_INDEX(node->ctx);
+
+	from = objs;
+	to_next = rte_node_next_stream_get(graph, node, next_index, nb_objs);
+	for (i = 0; i < nb_objs; i++) {
+
+		mbuf = (struct rte_mbuf *)objs[i];
+
+		/* Send mbuf to next enabled feature */
+		mbfields = rte_graph_feature_arc_mbuf_dynfields_get(mbuf, feat_dyn_off);
+		rte_graph_feature_data_next_feature_get(arc, &mbfields->feature_data, &next);
+
+		if (unlikely(next_index != next)) {
+			/* Copy things successfully speculated till now */
+			rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
+			from += last_spec;
+			to_next += last_spec;
+			held += last_spec;
+			last_spec = 0;
+
+			rte_node_enqueue_x1(graph, node, next, from[0]);
+			from += 1;
+		} else {
+			last_spec += 1;
+		}
+	}
+	/* !!! Home run !!! */
+	if (likely(last_spec == nb_objs)) {
+		rte_node_next_stream_move(graph, node, next_index);
+		return nb_objs;
+	}
+	held += last_spec;
+	rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
+	rte_node_next_stream_put(graph, node, next_index, held);
+	OUTPUT_HOOK_LAST_NEXT_INDEX(node->ctx) = next;
+
+	return nb_objs;
+}
+
+static int
+app_graph_ip4_output_hook_node1_init(const struct rte_graph *graph, struct rte_node *node)
+{
+	return __app_graph_ip4_output_hook_node_init(graph, node);
+}
+
+static __rte_always_inline uint16_t
+app_graph_ip4_output_hook_node1_process(struct rte_graph *graph, struct rte_node *node,
+					void **objs, uint16_t nb_objs)
+{
+	return __app_graph_ip4_output_hook_node_process(graph, node, objs, nb_objs);
+}
+
+static struct rte_node_register app_graph_ip4_output_hook_node1 = {
+	.process = app_graph_ip4_output_hook_node1_process,
+	.init = app_graph_ip4_output_hook_node1_init,
+	.name = "app_ip4_output_node1",
+	.nb_edges = 2,
+	.next_nodes = {
+		[0] = "pkt_drop",
+		[1] = "pkt_cls",
+	},
+};
+
+RTE_NODE_REGISTER(app_graph_ip4_output_hook_node1);
+
+static int
+app_graph_ip4_output_hook_node2_init(const struct rte_graph *graph, struct rte_node *node)
+{
+	return __app_graph_ip4_output_hook_node_init(graph, node);
+}
+
+static __rte_always_inline uint16_t
+app_graph_ip4_output_hook_node2_process(struct rte_graph *graph, struct rte_node *node,
+					void **objs, uint16_t nb_objs)
+{
+	return __app_graph_ip4_output_hook_node_process(graph, node, objs, nb_objs);
+}
+
+static struct rte_node_register app_graph_ip4_output_hook_node2 = {
+	.process = app_graph_ip4_output_hook_node2_process,
+	.init = app_graph_ip4_output_hook_node2_init,
+	.name = "app_ip4_output_node2",
+	.nb_edges = 1,
+	.next_nodes = {
+		[0] = "pkt_drop",
+	},
+};
+
+RTE_NODE_REGISTER(app_graph_ip4_output_hook_node2);
+
+/* if feature1 */
+struct rte_graph_feature_register app_graph_ip4_output_hook_feature1 = {
+	.feature_name = IP4_OUTPUT_HOOK_FEATURE1_NAME,
+	.arc_name = RTE_IP4_OUTPUT_FEATURE_ARC_NAME,
+	/* Same as regular function */
+	.feature_process_fn = app_graph_ip4_output_hook_node1_process,
+	.feature_node = &app_graph_ip4_output_hook_node1,
+	.runs_before =  IP4_OUTPUT_HOOK_FEATURE2_NAME,
+};
+
+/* if feature2 (same as f1) */
+struct rte_graph_feature_register app_graph_ip4_output_hook_feature2 = {
+	.feature_name = IP4_OUTPUT_HOOK_FEATURE2_NAME,
+	.arc_name = RTE_IP4_OUTPUT_FEATURE_ARC_NAME,
+	/* Same as regular function */
+	.feature_node = &app_graph_ip4_output_hook_node2,
+	.feature_process_fn = app_graph_ip4_output_hook_node2_process,
+};
+
+RTE_GRAPH_FEATURE_REGISTER(app_graph_ip4_output_hook_feature1);
+RTE_GRAPH_FEATURE_REGISTER(app_graph_ip4_output_hook_feature2);

--- a/app/graph/l3fwd.c
+++ b/app/graph/l3fwd.c
@@ -52,6 +52,9 @@ l3fwd_pattern_configure(void)
 	graph_conf.pcap_enable = pcap_ena;
 	graph_conf.num_pkt_to_capture = pcap_pkts_count;
 	graph_conf.pcap_filename = strdup(pcap_file);
+	graph_conf.feature_arc_enable = false;
+	if (app_graph_feature_arc_enabled())
+		graph_conf.feature_arc_enable = true;
 
 	for (lcore_id = 0; lcore_id < RTE_MAX_LCORE; lcore_id++) {
 		rte_graph_t graph_id;

--- a/app/graph/main.c
+++ b/app/graph/main.c
@@ -28,6 +28,7 @@ static struct app_params {
 	struct conn_params conn;
 	char *script_name;
 	bool enable_graph_stats;
+	bool enable_feature_arc;
 } app = {
 	.conn = {
 		.welcome = "\nWelcome!\n\n",
@@ -42,6 +43,7 @@ static struct app_params {
 	},
 	.script_name = NULL,
 	.enable_graph_stats = false,
+	.enable_feature_arc = false,
 };
 
 static void
@@ -59,6 +61,7 @@ app_args_parse(int argc, char **argv)
 	struct option lgopts[] = {
 		{"help", 0, 0, 'H'},
 		{"enable-graph-stats", 0, 0, 'g'},
+		{"enable-graph-feature-arc", 0, 0, 'f'},
 	};
 	int h_present, p_present, s_present, n_args, i;
 	char *app_name = argv[0];
@@ -81,7 +84,7 @@ app_args_parse(int argc, char **argv)
 	p_present = 0;
 	s_present = 0;
 
-	while ((opt = getopt_long(argc, argv, "h:p:s:", lgopts, &option_index)) != EOF) {
+	while ((opt = getopt_long(argc, argv, "h:p:s:f", lgopts, &option_index)) != EOF) {
 		switch (opt) {
 		case 'h':
 			if (h_present) {
@@ -142,6 +145,10 @@ app_args_parse(int argc, char **argv)
 			       "--enable-graph-stats");
 			break;
 
+		case 'f':
+			app.enable_feature_arc = true;
+			break;
+
 		case 'H':
 		default:
 			printf(usage, app_name);
@@ -157,6 +164,12 @@ bool
 app_graph_stats_enabled(void)
 {
 	return app.enable_graph_stats;
+}
+
+bool
+app_graph_feature_arc_enabled(void)
+{
+	return app.enable_feature_arc;
 }
 
 bool

--- a/app/graph/main.c
+++ b/app/graph/main.c
@@ -147,6 +147,7 @@ app_args_parse(int argc, char **argv)
 
 		case 'f':
 			app.enable_feature_arc = true;
+			printf("Feature arc is enabled from command line\n");
 			break;
 
 		case 'H':

--- a/app/graph/meson.build
+++ b/app/graph/meson.build
@@ -24,6 +24,8 @@ sources = files(
         'mempool.c',
         'neigh.c',
         'utils.c',
+        'feature.c',
+        'ip4_output_hook.c'
 )
 
 cmd_h = custom_target('commands_hdr',

--- a/app/graph/module_api.h
+++ b/app/graph/module_api.h
@@ -20,6 +20,7 @@
 #include "neigh.h"
 #include "route.h"
 #include "utils.h"
+#include "feature.h"
 
 /*
  * Externs
@@ -28,6 +29,7 @@ extern volatile bool force_quit;
 extern struct conn *conn;
 
 bool app_graph_stats_enabled(void);
+bool app_graph_feature_arc_enabled(void);
 bool app_graph_exit(void);
 
 #endif

--- a/doc/api/doxy-api-index.md
+++ b/doc/api/doxy-api-index.md
@@ -214,6 +214,8 @@ The public API headers are grouped by topics:
     [table_wm](@ref rte_swx_table_wm.h)
   * [graph](@ref rte_graph.h):
     [graph_worker](@ref rte_graph_worker.h)
+    [graph_feature_arc](@ref rte_graph_feature_arc.h)
+    [graph_feature_arc_worker](@ref rte_graph_feature_arc_worker.h)
   * graph_nodes:
     [eth_node](@ref rte_node_eth_api.h),
     [ip4_node](@ref rte_node_ip4_api.h),

--- a/lib/graph/graph.c
+++ b/lib/graph/graph.c
@@ -16,6 +16,7 @@
 
 #include "graph_private.h"
 #include "graph_pcap_private.h"
+#include "graph_feature_nodes.h"
 
 static struct graph_head graph_list = STAILQ_HEAD_INITIALIZER(graph_list);
 static rte_spinlock_t graph_lock = RTE_SPINLOCK_INITIALIZER;
@@ -65,6 +66,35 @@ graph_insert_ordered(struct graph *graph)
 	} else {
 		STAILQ_INSERT_AFTER(&graph_list, after, graph, next);
 	}
+}
+
+static uint16_t
+feature_arc_start_node_process(struct rte_graph *graph, struct rte_node *node,
+			       void **objs, uint16_t nb_objs)
+{
+	struct rte_graph_feature_arc *arc =
+		(struct rte_graph_feature_arc *)node->feature_arc_ptr;
+
+	RTE_SET_USED(objs);
+	RTE_SET_USED(nb_objs);
+
+	if (rte_graph_feature_arc_is_any_feature_enabled(arc))
+		return feature_arc_node_process(graph, node, objs, nb_objs,
+						1 /* start_node */,
+						1 /* feature maybe enabled*/);
+	else
+		return feature_arc_node_process(graph, node, objs, nb_objs,
+						1 /* start_node */,
+						0 /* feature not enabled */);
+}
+
+static uint16_t
+feature_arc_non_start_node_process(struct rte_graph *graph, struct rte_node *node,
+				   void **objs, uint16_t nb_objs)
+{
+	return feature_arc_node_process(graph, node, objs, nb_objs,
+					0 /* non start node*/,
+					1 /* feature has to be enabled as this node is called */);
 }
 
 struct graph_head *
@@ -159,6 +189,163 @@ graph_node_edges_add(struct graph *graph)
 	return 0;
 fail:
 	return -rte_errno;
+}
+
+static int
+graph_arc_register_interim_nodes(struct graph *graph, struct node *parent)
+{
+	struct rte_node_register *reg;
+	rte_edge_t i, j, fi, nb_edges;
+	char name[RTE_NODE_NAMESIZE];
+	struct node *child = NULL;
+	char **next_names;
+	size_t sz;
+
+	RTE_SET_USED(graph);
+
+	if (parent->finfo.flags & NODE_F_ARC_REVISITED)
+		return 0;
+
+	/* Depth first search */
+	for (i = 0; i < parent->nb_edges; i++) {
+		child = node_from_name(parent->next_nodes[i]);
+
+		if (!(child->finfo.flags & NODE_F_ARC))
+			continue;
+
+		if (!parent->finfo.num_feature_nodes)
+			parent->finfo.first_arc_enabled_next_index = i;
+
+		parent->finfo.num_feature_nodes++;
+
+		if (!(child->finfo.flags & NODE_F_ARC_REVISITED))
+			graph_arc_register_interim_nodes(graph, child);
+	}
+
+	parent->finfo.flags |= NODE_F_ARC_REVISITED;
+
+	if (!parent->finfo.num_feature_nodes ||
+	    !parent->nb_edges)
+		return 0;
+
+	/* feature node should at least have one non-feature child */
+	if (parent->nb_edges == parent->finfo.num_feature_nodes)
+		return 0;
+
+	fi = parent->finfo.first_arc_enabled_next_index;
+
+	/* 0th index + num_feature_nodes are nb_edges */
+	nb_edges = parent->finfo.num_feature_nodes + 1;
+
+	for(i = 0; i < fi; i++) {
+		reg = NULL;
+		snprintf(name, RTE_NODE_NAMESIZE, "%s-f%d", parent->name, i);
+
+		sz = sizeof(*reg) + (sizeof(char *) * nb_edges);
+		reg = calloc(1, sz);
+		if (!reg)
+			SET_ERR_JMP(ENOMEM, free_reg, "Failed to malloc %s node_reg",
+				    name);
+
+		next_names= calloc(nb_edges, sizeof(char *));
+		if (!next_names)
+			SET_ERR_JMP(ENOMEM, free_name_arr, "Failed to malloc %s next_names",
+				    name);
+
+		for (j = 0; j < nb_edges; j++) {
+			next_names[j] = calloc(1, (RTE_NODE_NAMESIZE + 1));
+			if (!next_names[j])
+				SET_ERR_JMP(ENOMEM, free_name_arr_mem, "Failed to malloc %s next_names[%u]",
+					    name, j);
+		}
+
+		reg->nb_edges = nb_edges;
+
+		if (parent->finfo.flags & NODE_F_ARC_START_NODE)
+			reg->process = feature_arc_start_node_process;
+		else
+			reg->process = feature_arc_non_start_node_process;
+
+		reg->init = feature_arc_interim_node_init;
+		rte_strscpy(reg->name, name, RTE_NODE_NAMESIZE);
+
+		for (j = 0; j < nb_edges; j++) {
+			if (j) {
+				rte_strscpy(next_names[j],
+					    parent->next_nodes[fi + j - 1],
+					    RTE_NODE_NAMESIZE);
+				reg->next_nodes[j] = next_names[j];
+			} else {
+				rte_strscpy(next_names[0], parent->next_nodes[i],
+					    RTE_NODE_NAMESIZE);
+				reg->next_nodes[0] = next_names[0];
+			}
+		}
+
+		/* register new node */
+		graph_spinlock_unlock();
+		reg->id = __rte_node_register(reg);
+		graph_spinlock_lock();
+
+		if (reg->id == RTE_NODE_ID_INVALID)
+			SET_ERR_JMP(ENOMEM, free_reg, "Failed to register %s object",
+				    name);
+
+		/* Hook child to parent node */
+		rte_strscpy(parent->next_nodes[i], reg->name, RTE_NODE_NAMESIZE);
+
+		/* setup child node */
+		child = node_from_name(reg->name);
+		if (!child)
+			SET_ERR_JMP(ENOMEM, free_name_arr_mem, "Failed to get %s registered node",
+				    name);
+		/* graph add  */
+		if(graph_node_add(graph, child))
+			SET_ERR_JMP(ENOMEM, free_name_arr_mem, "Failed to add %s node to graph",
+				    name);
+
+		rte_strscpy(child->finfo.arc_name, parent->finfo.arc_name, RTE_NODE_NAMESIZE);
+		child->finfo.first_arc_enabled_next_index = 1;
+		child->finfo.fp_adjust_index = fi -1;
+		child->finfo.num_feature_nodes = nb_edges - 1;
+		child->finfo.flags = NODE_F_ARC_INTERIM_NODE;
+
+		for (j = 0; j < nb_edges; j++)
+			free(next_names[j]);
+		free(next_names);
+		free(reg);
+	}
+
+	return 0;
+
+free_name_arr_mem:
+	for (j = 0; j < nb_edges; j++)
+		free(next_names[j]);
+free_name_arr:
+	free(next_names);
+free_reg:
+	free(reg);
+
+	return -rte_errno;
+}
+
+static int
+graph_node_add_with_arc(struct graph *graph)
+{
+	struct graph_node *graph_node;
+	struct node *parent;
+
+	STAILQ_FOREACH(graph_node, &graph->node_list, next) {
+		parent = graph_node->node;
+		if (!(parent->finfo.flags & NODE_F_ARC))
+			continue;
+
+		if (!(parent->finfo.flags & NODE_F_ARC_START_NODE))
+			continue;
+
+		graph_arc_register_interim_nodes(graph, parent);
+	}
+	return 0;
 }
 
 static int
@@ -387,6 +574,9 @@ rte_graph_create(const char *name, struct rte_graph_param *prm)
 	const char *pattern;
 	uint16_t i;
 
+	if (prm && prm->feature_arc_enable)
+		rte_graph_feature_arc_init();
+
 	graph_spinlock_lock();
 
 	/* Check arguments sanity */
@@ -418,6 +608,11 @@ rte_graph_create(const char *name, struct rte_graph_param *prm)
 		if (expand_pattern_to_node(graph, pattern))
 			goto graph_cleanup;
 	}
+
+	/* Go over all nodes and add nodes with feature arc enabled */
+	if (prm->feature_arc_enable)
+		if (graph_node_add_with_arc(graph))
+			goto graph_cleanup;
 
 	/* Go over all the nodes edges and add them to the graph */
 	if (graph_node_edges_add(graph))

--- a/lib/graph/graph_feature_arc.c
+++ b/lib/graph/graph_feature_arc.c
@@ -819,7 +819,9 @@ rte_graph_feature_arc_create(struct rte_graph_feature_arc_register *reg,
 	memset(arc->feature_bit_mask_by_index, 0, sizeof(uint64_t) * reg->max_indexes);
 
 	/* override process function with start_node */
-	if (node_override_process_func(reg->start_node->id, reg->start_node_feature_process_fn)) {
+	if (node_override_process_func(reg->start_node->id,
+				       reg->start_node_feature_process_fn, true,
+				       reg->arc_name)) {
 		graph_err("node_override_process_func failed for %s", reg->start_node->name);
 		rte_free(arc->feature_bit_mask_by_index);
 		rte_memzone_free(mz);
@@ -1070,12 +1072,13 @@ rte_graph_feature_add(struct rte_graph_feature_register *freg)
 						STAILQ_INSERT_HEAD(&arc->all_features, finfo,
 								   next_feature);
 
-					/* override node process fn */
+					/* override node_process_fn */
 					rc = node_override_process_func(finfo->feature_node_id,
-									freg->feature_process_fn);
-
+									freg->feature_process_fn,
+									false,
+									arc->feature_arc_name);
 					if (rc < 0) {
-						graph_err("node_override_process_func failed for %s",
+						graph_err("node_override_func failed for %s",
 							  freg->feature_name);
 						goto finfo_free;
 					}
@@ -1089,7 +1092,9 @@ rte_graph_feature_add(struct rte_graph_feature_register *freg)
 		}
 	}
 	/* override node_process_fn */
-	rc = node_override_process_func(finfo->feature_node_id, freg->feature_process_fn);
+	rc = node_override_process_func(finfo->feature_node_id,
+					freg->feature_process_fn, false,
+					arc->feature_arc_name);
 	if (rc < 0) {
 		graph_err("node_override_process_func failed for %s", freg->feature_name);
 		goto finfo_free;

--- a/lib/graph/graph_feature_arc.c
+++ b/lib/graph/graph_feature_arc.c
@@ -1,0 +1,1792 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+
+#include "graph_private.h"
+#include <rte_graph_feature_arc_worker.h>
+#include <rte_malloc.h>
+#include <rte_string_fns.h>
+
+#define GRAPH_FEATURE_ARC_INITIALIZER  UINT64_MAX
+#define GRAPH_FEATURE_MAX_NUM_PER_ARC  (64)
+
+#define connect_graph_nodes(node1, node2, edge, arc_name) \
+	__connect_graph_nodes(node1, node2, edge, arc_name, __LINE__)
+
+#define FEATURE_ARC_MEMZONE_NAME "__rte_feature_arc_main_mz"
+
+#define graph_uint_cast(f)		((unsigned int)f)
+
+#define fdata_from_feat(arc, feat, index)	\
+			RTE_GRAPH_FEATURE_TO_FEATURE_DATA(arc, feat, index)
+
+#define feat_dbg graph_dbg
+
+#define FEAT_COND_ERR(cond, ...)                                           \
+	do {                                                               \
+		if (cond)                                                  \
+			graph_err(__VA_ARGS__);                            \
+	} while (0)
+
+#define FEAT_ERR(fn, ln, ...)                                              \
+		GRAPH_LOG2(ERR, fn, ln, __VA_ARGS__)
+
+#define FEAT_ERR_JMP(_err, fn, ln, ...)                                    \
+	do {                                                               \
+		FEAT_ERR(fn, ln, __VA_ARGS__);                             \
+		rte_errno = _err;                                          \
+	} while (0)
+
+static struct rte_mbuf_dynfield rte_graph_feature_arc_mbuf_desc = {
+	.name = RTE_GRAPH_FEATURE_ARC_DYNFIELD_NAME,
+	.size = sizeof(struct rte_graph_feature_arc_mbuf_dynfields),
+	.align = alignof(struct rte_graph_feature_arc_mbuf_dynfields),
+};
+
+rte_graph_feature_arc_main_t *__rte_graph_feature_arc_main;
+int __rte_graph_feature_arc_mbuf_dyn_offset = -1;
+
+/* global feature arc list */
+static STAILQ_HEAD(, rte_graph_feature_arc_register) feature_arc_list =
+					STAILQ_HEAD_INITIALIZER(feature_arc_list);
+
+/* global feature arc list */
+static STAILQ_HEAD(, rte_graph_feature_register) feature_list =
+					STAILQ_HEAD_INITIALIZER(feature_list);
+
+/* feature registration validate */
+static int
+feature_registration_validate(struct rte_graph_feature_register *feat_entry,
+			      const char *caller_name, int lineno,
+			      int check_node_reg_id, /* check feature_node->id */
+			      int check_feat_reg_id /* check feature->feature_node_id */)
+{
+	if (!feat_entry) {
+		FEAT_ERR(caller_name, lineno, "NULL feature reg");
+		return -1;
+	}
+
+	if (!feat_entry->feature_name) {
+		FEAT_ERR(caller_name, lineno,
+			 "NULL feature name %p", feat_entry);
+		return -1;
+	}
+
+	if (!feat_entry->arc_name) {
+		FEAT_ERR(caller_name, lineno,
+			 "No associated arc provided for feature: %s",
+			 feat_entry->feature_name);
+		return -1;
+	}
+
+	if (!feat_entry->feature_process_fn) {
+		FEAT_ERR(caller_name, lineno,
+			 "No process function provided for feature: %s",
+			 feat_entry->feature_name);
+		return -1;
+	}
+
+	if (!feat_entry->feature_node) {
+		FEAT_ERR(caller_name, lineno,
+			 "No feature node provided for feature: %s",
+			 feat_entry->feature_name);
+		return -1;
+	}
+
+	if (check_node_reg_id && (feat_entry->feature_node->id == RTE_NODE_ID_INVALID)) {
+		FEAT_ERR(caller_name, lineno,
+			 "feature_node with invalid node id found for feature: %s",
+			 feat_entry->feature_name);
+		return -1;
+	}
+
+	if (check_feat_reg_id && (feat_entry->feature_node_id == RTE_NODE_ID_INVALID)) {
+		FEAT_ERR(caller_name, lineno,
+			 "feature_node_id found invalid for feature: %s",
+			 feat_entry->feature_name);
+		return -1;
+	}
+
+	return 0;
+
+}
+
+/* validate arc registration */
+static int
+arc_registration_validate(struct rte_graph_feature_arc_register *reg,
+			  const char *caller_name, int lineno)
+{
+	if (!reg->arc_name) {
+		FEAT_ERR_JMP(EINVAL, caller_name, lineno,
+			     "feature_arc name cannot be NULL");
+		return -1;
+	}
+
+	if (reg->max_features > GRAPH_FEATURE_MAX_NUM_PER_ARC) {
+		FEAT_ERR_JMP(EAGAIN, caller_name, lineno,
+			     "arc: %s, number of features are more than max",
+			     reg->arc_name);
+		return -1;
+	}
+
+	if (!reg->max_indexes) {
+		FEAT_ERR_JMP(EINVAL, caller_name, lineno,
+			     "Zero max_indexes found for arc: %s",
+			     reg->arc_name);
+		return -1;
+	}
+
+	if (!reg->start_node) {
+		FEAT_ERR_JMP(EINVAL, caller_name, lineno,
+			     "start node cannot be NULL for arc: %s",
+			     reg->arc_name);
+		return -1;
+	}
+
+	if (!reg->start_node_feature_process_fn) {
+		FEAT_ERR_JMP(EINVAL, caller_name, lineno,
+			     "start node feature_process_fn() cannot be NULL for arc: %s",
+			     reg->arc_name);
+		return -1;
+	}
+
+	return (feature_registration_validate(reg->end_feature, caller_name, lineno, 0, 0));
+}
+
+/* lookup arc registration by name */
+static int arc_registration_num(void)
+{
+	struct rte_graph_feature_arc_register *entry = NULL;
+	int num = 0;
+
+	STAILQ_FOREACH(entry, &feature_arc_list, next_arc)
+		num++;
+
+	return num;
+}
+
+
+/* lookup arc registration by name */
+static int arc_registration_lookup(const char *arc_name,
+				   struct rte_graph_feature_arc_register **arc_entry)
+{
+	struct rte_graph_feature_arc_register *entry = NULL;
+
+	STAILQ_FOREACH(entry, &feature_arc_list, next_arc) {
+		if (arc_registration_validate(entry, __func__, __LINE__) < 0)
+			continue;
+
+		if (!strncmp(entry->arc_name, arc_name, RTE_GRAPH_FEATURE_ARC_NAMELEN)) {
+			if (arc_entry)
+				*arc_entry = entry;
+			return 1;
+		}
+	}
+
+	return 0;
+}
+
+
+/* Number of features registered for an ARC
+ *
+ * i.e number of RTE_GRAPH_FEATURE_REGISTER() for an arc
+ */
+static int
+arc_registered_features_num(const char *arc_name, uint32_t *num_features)
+{
+	struct rte_graph_feature_arc_register *arc_reg = NULL;
+	struct rte_graph_feature_register *feat_entry = NULL;
+	uint32_t num = 0;
+
+	/* Check if arc is registered with end_feature */
+	if (!arc_registration_lookup(arc_name, &arc_reg))
+		return -1;
+
+	if (arc_reg->end_feature)
+		num++;
+
+	/* Calculate features other than end_feature added in arc */
+	STAILQ_FOREACH(feat_entry, &feature_list, next_feature) {
+		if (feature_registration_validate(feat_entry, __func__, __LINE__, 1, 0) < 0)
+			continue;
+
+		if (!strncmp(feat_entry->arc_name, arc_name, strlen(feat_entry->arc_name)))
+			num++;
+	}
+
+	if (num_features)
+		*num_features = num;
+
+	return 0;
+}
+
+/* calculate arc size to be allocated */
+static int
+feature_arc_reg_calc_size(struct rte_graph_feature_arc_register *reg, size_t *sz,
+			  uint16_t *feat_off, uint16_t *fdata_off, uint32_t *fsz)
+{
+	size_t ff_size = 0, fdata_size = 0;
+
+	/* first feature array per index */
+	ff_size = RTE_ALIGN_CEIL(sizeof(rte_graph_feature_t) * reg->max_indexes,
+				 RTE_CACHE_LINE_SIZE);
+
+	/* fdata size per feature */
+	*fsz = (uint32_t)RTE_ALIGN_CEIL(sizeof(struct rte_graph_feature_data) * reg->max_indexes,
+					RTE_CACHE_LINE_SIZE);
+
+	/* Allocate feature_data extra by 2.
+	 * 0th index is used for first feature data from start_node
+	 * Last feature data is used for dummy_fdata for end_feature
+	 */
+	fdata_size = (*fsz) * (reg->max_features + 2);
+
+	if (sz)
+		*sz = fdata_size + ff_size + sizeof(struct rte_graph_feature_arc);
+	if (feat_off)
+		*feat_off = sizeof(struct rte_graph_feature_arc);
+	if (fdata_off)
+		*fdata_off = ff_size + sizeof(struct rte_graph_feature_arc);
+
+	return 0;
+}
+
+static rte_graph_feature_t *
+graph_first_feature_ptr_get(struct rte_graph_feature_arc *arc,
+			    uint32_t index)
+{
+	return (rte_graph_feature_t *)((uint8_t *)arc + arc->fp_first_feature_offset +
+				       (sizeof(rte_graph_feature_t) * index));
+}
+
+static int
+feature_arc_data_reset(struct rte_graph_feature_arc *arc)
+{
+	rte_graph_feature_data_t first_fdata;
+	struct rte_graph_feature_data *fdata;
+	rte_graph_feature_t iter, *f = NULL;
+	uint16_t index;
+
+	arc->runtime_enabled_features = 0;
+
+	for (index = 0; index < arc->max_indexes; index++) {
+		f = graph_first_feature_ptr_get(arc, index);
+		*f = RTE_GRAPH_FEATURE_INVALID;
+	}
+
+	for (iter = 0; iter < arc->max_features; iter++) {
+		first_fdata = fdata_from_feat(arc, iter, 0);
+		for (index = 0; index < arc->max_indexes; index++) {
+			fdata = rte_graph_feature_data_get(arc, first_fdata + index);
+			fdata->next_feature_data = RTE_GRAPH_FEATURE_DATA_INVALID;
+			fdata->app_cookie = UINT16_MAX;
+			fdata->next_edge = RTE_EDGE_ID_INVALID;
+		}
+	}
+	return 0;
+}
+
+/*
+ * lookup feature name and get control path node_list as well as feature index
+ * at which it is inserted
+ */
+static int
+nodeinfo_lkup_by_name(struct rte_graph_feature_arc *arc, const char *feat_name,
+		      struct rte_graph_feature_node_list **ffinfo, uint32_t *slot)
+{
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t fi = 0;
+
+	if (!feat_name)
+		return -1;
+
+	if (slot)
+		*slot = UINT32_MAX;
+
+	STAILQ_FOREACH(finfo, &arc->all_features, next_feature) {
+		RTE_VERIFY(finfo->feature_arc == arc);
+		if (!strncmp(finfo->feature_name, feat_name, strlen(finfo->feature_name))) {
+			if (ffinfo)
+				*ffinfo = finfo;
+			if (slot)
+				*slot = fi;
+			return 0;
+		}
+		fi++;
+	}
+	return -1;
+}
+
+/* Lookup used only during rte_graph_feature_add() */
+static int
+nodeinfo_add_lookup(struct rte_graph_feature_arc *arc, const char *feat_node_name,
+		    struct rte_graph_feature_node_list **ffinfo, uint32_t *slot)
+{
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t fi = 0;
+
+	if (!feat_node_name)
+		return -1;
+
+	if (slot)
+		*slot = 0;
+
+	STAILQ_FOREACH(finfo, &arc->all_features, next_feature) {
+		RTE_VERIFY(finfo->feature_arc == arc);
+		if (!strncmp(finfo->feature_name, feat_node_name, strlen(finfo->feature_name))) {
+			if (ffinfo)
+				*ffinfo = finfo;
+			if (slot)
+				*slot = fi;
+			return 0;
+		}
+		/* Update slot where new feature can be added */
+		if (slot)
+			*slot = fi;
+		fi++;
+	}
+
+	return -1;
+}
+
+/* Get control path node info from provided input feature_index */
+static int
+nodeinfo_lkup_by_index(struct rte_graph_feature_arc *arc, uint32_t feature_index,
+		       struct rte_graph_feature_node_list **ppfinfo,
+		       const int do_sanity_check)
+{
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t index = 0;
+
+	if (!ppfinfo)
+		return -1;
+
+	*ppfinfo = NULL;
+	STAILQ_FOREACH(finfo, &arc->all_features, next_feature) {
+		/* Check sanity */
+		if (do_sanity_check)
+			if (finfo->finfo_index != index)
+				RTE_VERIFY(0);
+		if (index == feature_index) {
+			*ppfinfo = finfo;
+			return 0;
+		}
+		index++;
+	}
+	return -1;
+}
+
+/* get existing edge from parent_node -> child_node */
+static int
+get_existing_edge(const char *arc_name, rte_node_t parent_node,
+		  rte_node_t child_node, rte_edge_t *_edge)
+{
+	char **next_edges = NULL;
+	uint32_t i, count = 0;
+
+	RTE_SET_USED(arc_name);
+
+	count = rte_node_edge_get(parent_node, NULL);
+
+	if (!count)
+		return -1;
+
+	next_edges = malloc(count);
+
+	if (!next_edges)
+		return -1;
+
+	count = rte_node_edge_get(parent_node, next_edges);
+	for (i = 0; i < count; i++) {
+		if (strstr(rte_node_id_to_name(child_node), next_edges[i])) {
+			if (_edge)
+				*_edge = (rte_edge_t)i;
+
+			free(next_edges);
+			return 0;
+		}
+	}
+	free(next_edges);
+
+	return -1;
+}
+
+
+/* prepare feature arc after addition of all features */
+static int
+prepare_feature_arc_before_first_enable(struct rte_graph_feature_arc *arc)
+{
+	struct rte_graph_feature_node_list *lfinfo = NULL;
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t index = 0, iter;
+	rte_edge_t edge;
+
+	STAILQ_FOREACH(lfinfo, &arc->all_features, next_feature) {
+		lfinfo->finfo_index = index;
+		index++;
+	}
+	if (!index) {
+		graph_err("No feature added to arc: %s", arc->feature_arc_name);
+		return -1;
+	}
+
+	nodeinfo_lkup_by_index(arc, index - 1, &lfinfo, 0);
+
+	/* lfinfo should be the info corresponding to end_feature
+	 * Add edge from all features to end feature node to have exception path
+	 * in fast path from all feature nodes to end feature node during enable/disable
+	 */
+	if (lfinfo->feature_node_id != arc->end_feature.feature_node_id) {
+		graph_err("end_feature node mismatch [found-%s: exp-%s]",
+			  rte_node_id_to_name(lfinfo->feature_node_id),
+			  rte_node_id_to_name(arc->end_feature.feature_node_id));
+		return -1;
+	}
+
+	STAILQ_FOREACH(finfo, &arc->all_features, next_feature) {
+		if (get_existing_edge(arc->feature_arc_name, arc->start_node->id,
+				      finfo->feature_node_id, &edge)) {
+			graph_err("No edge found from %s to %s",
+				  rte_node_id_to_name(arc->start_node->id),
+				  rte_node_id_to_name(finfo->feature_node_id));
+			return -1;
+		}
+		finfo->edge_to_this_feature = edge;
+
+		if (finfo == lfinfo)
+			continue;
+
+		if (get_existing_edge(arc->feature_arc_name, finfo->feature_node_id,
+				      lfinfo->feature_node_id, &edge)) {
+			graph_err("No edge found from %s to %s",
+				  rte_node_id_to_name(finfo->feature_node_id),
+				  rte_node_id_to_name(lfinfo->feature_node_id));
+			return -1;
+		}
+		finfo->edge_to_last_feature = edge;
+	}
+	/**
+	 * Enable end_feature in control bitmask
+	 * (arc->feature_bit_mask_by_index) but not in fast path bitmask
+	 * arc->fp_feature_enable_bitmask. This is due to:
+	 * 1. Application may not explicitly enabling end_feature node
+	 * 2. However it should be enabled internally so that when a feature is
+	 *    disabled (say on an interface), next_edge of data should be
+	 *    updated to end_feature node hence packet can exit arc.
+	 * 3. We do not want to set bit for end_feature in fast path bitmask as
+	 *    it will void the purpose of fast path APIs
+	 *    rte_graph_feature_arc_is_any_feature_enabled(). Since enabling
+	 *    end_feature would make these APIs to always return "true"
+	 */
+	for (iter = 0; iter < arc->max_indexes; iter++)
+		arc->feature_bit_mask_by_index[iter] |= (1 << lfinfo->finfo_index);
+
+	return 0;
+}
+
+/* feature arc sanity */
+static int
+feature_arc_sanity(rte_graph_feature_arc_t _arc)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	rte_graph_feature_arc_main_t *dm = __rte_graph_feature_arc_main;
+	uint16_t iter;
+
+	if (!__rte_graph_feature_arc_main)
+		return -1;
+
+	if (!arc)
+		return -1;
+
+	for (iter = 0; iter < dm->max_feature_arcs; iter++) {
+		if (arc == rte_graph_feature_arc_get(iter)) {
+			if (arc->feature_arc_index != iter)
+				return -1;
+			if (arc->feature_arc_main != dm)
+				return -1;
+
+			return 0;
+		}
+	}
+	return -1;
+}
+
+/* create or retrieve already existing edge from parent_node -> child_node */
+static int
+__connect_graph_nodes(rte_node_t parent_node, rte_node_t child_node,
+		    rte_edge_t *_edge, char *arc_name, int lineno)
+{
+	const char *next_node = NULL;
+	rte_edge_t edge;
+
+	if (!get_existing_edge(arc_name, parent_node, child_node, &edge)) {
+		feat_dbg("\t%s/%d: %s[%u]: \"%s\", edge reused", arc_name, lineno,
+			 rte_node_id_to_name(parent_node), edge, rte_node_id_to_name(child_node));
+
+		if (_edge)
+			*_edge = edge;
+
+		return 0;
+	}
+
+	/* Node to be added */
+	next_node = rte_node_id_to_name(child_node);
+
+	edge = rte_node_edge_update(parent_node, RTE_EDGE_ID_INVALID, &next_node, 1);
+
+	if (edge == RTE_EDGE_ID_INVALID) {
+		graph_err("edge invalid");
+		return -1;
+	}
+	edge = rte_node_edge_count(parent_node) - 1;
+
+	feat_dbg("\t%s/%d: %s[%u]: \"%s\", new edge added", arc_name, lineno,
+		 rte_node_id_to_name(parent_node), edge, rte_node_id_to_name(child_node));
+
+	if (_edge)
+		*_edge = edge;
+
+	return 0;
+}
+
+/* feature arc initialization */
+static int
+feature_arc_main_init(rte_graph_feature_arc_main_t **pfl, uint32_t max_feature_arcs)
+{
+	rte_graph_feature_arc_main_t *pm = NULL;
+	const struct rte_memzone *mz = NULL;
+	uint32_t i;
+	size_t sz;
+
+	if (!pfl) {
+		graph_err("Invalid input");
+		return -1;
+	}
+
+	__rte_graph_feature_arc_mbuf_dyn_offset =
+		rte_mbuf_dynfield_register(&rte_graph_feature_arc_mbuf_desc);
+
+	if (__rte_graph_feature_arc_mbuf_dyn_offset < 0) {
+		graph_err("rte_graph_feature_arc_dynfield_register failed");
+		return -1;
+	}
+
+	sz = sizeof(rte_graph_feature_arc_main_t) +
+		(sizeof(pm->feature_arcs[0]) * max_feature_arcs);
+
+	mz = rte_memzone_reserve(FEATURE_ARC_MEMZONE_NAME, sz, SOCKET_ID_ANY, 0);
+	if (!mz) {
+		graph_err("memzone reserve failed for feature arc main");
+		return -1;
+	}
+
+	pm = mz->addr;
+	memset(pm, 0, sz);
+
+	for (i = 0; i < max_feature_arcs; i++)
+		pm->feature_arcs[i] = GRAPH_FEATURE_ARC_INITIALIZER;
+
+	pm->max_feature_arcs = max_feature_arcs;
+
+	*pfl = pm;
+
+	return 0;
+}
+
+/* feature arc initialization, public API */
+int
+rte_graph_feature_arc_init(void)
+{
+	struct rte_graph_feature_arc_register *arc_reg = NULL;
+	struct rte_graph_feature_register *feat_reg = NULL;
+	const struct rte_memzone *mz = NULL;
+	int max_feature_arcs;
+	int rc = -1;
+
+	max_feature_arcs = arc_registration_num();
+
+	if (!max_feature_arcs) {
+		graph_err("No feature arcs registered");
+		return -1;
+	}
+
+	if (!__rte_graph_feature_arc_main) {
+		mz = rte_memzone_lookup(FEATURE_ARC_MEMZONE_NAME);
+		if (mz) {
+			__rte_graph_feature_arc_main = mz->addr;
+			__rte_graph_feature_arc_mbuf_dyn_offset =
+				rte_mbuf_dynfield_lookup(RTE_GRAPH_FEATURE_ARC_DYNFIELD_NAME,
+						 &rte_graph_feature_arc_mbuf_desc);
+		} else {
+			rc = feature_arc_main_init(&__rte_graph_feature_arc_main, max_feature_arcs);
+			if (rc < 0)
+				return rc;
+		}
+	}
+
+	STAILQ_FOREACH(arc_reg, &feature_arc_list, next_arc) {
+		/* validate end feature */
+		if (feature_registration_validate(arc_reg->end_feature,
+						  __func__, __LINE__, 1, 0) < 0)
+			continue;
+
+		if (strncmp(arc_reg->arc_name, arc_reg->end_feature->arc_name,
+			    RTE_GRAPH_FEATURE_ARC_NAMELEN)) {
+			feat_dbg("arc-%s: mismatch in arc_name for end_feature: %s",
+				 arc_reg->arc_name, arc_reg->end_feature->arc_name);
+			continue;
+		}
+
+		if (!arc_registration_lookup(arc_reg->arc_name, NULL))
+			continue;
+
+		/* If feature name not set, use node name as feature */
+		if (!arc_reg->end_feature->feature_name)
+			arc_reg->end_feature->feature_name =
+				rte_node_id_to_name(arc_reg->end_feature->feature_node_id);
+
+		/* If max_features not set, calculate number of static feature registrations */
+		if (!arc_reg->max_features)
+			arc_registered_features_num(arc_reg->arc_name, &arc_reg->max_features);
+
+		arc_reg->end_feature->feature_node_id = arc_reg->end_feature->feature_node->id;
+
+		rc = rte_graph_feature_arc_create(arc_reg, NULL);
+
+		if (rc < 0)
+			goto arc_cleanup;
+
+		rc = rte_graph_feature_add(arc_reg->end_feature);
+
+		if (rc < 0)
+			goto arc_cleanup;
+	}
+
+	/* First add those features which has no runs_after and runs_before restriction */
+	STAILQ_FOREACH(feat_reg, &feature_list, next_feature) {
+		if (feat_reg->runs_after || feat_reg->runs_before)
+			continue;
+
+		if (feature_registration_validate(feat_reg, __func__, __LINE__, 1, 0) < 0)
+			continue;
+
+		feat_reg->feature_node_id = feat_reg->feature_node->id;
+
+		rc = rte_graph_feature_add(feat_reg);
+
+		if (rc < 0)
+			goto arc_cleanup;
+	}
+	/* Add those features which has either runs_after or runs_before restrictions */
+	STAILQ_FOREACH(feat_reg, &feature_list, next_feature) {
+		if (!feat_reg->runs_after && !feat_reg->runs_before)
+			continue;
+
+		if (feat_reg->runs_after && feat_reg->runs_before)
+			continue;
+
+		if (feature_registration_validate(feat_reg, __func__, __LINE__, 1, 0) < 0)
+			continue;
+
+		feat_reg->feature_node_id = feat_reg->feature_node->id;
+
+		rc = rte_graph_feature_add(feat_reg);
+
+		if (rc < 0)
+			goto arc_cleanup;
+	}
+	/* Add those features with both runs_after and runs_before restrictions */
+	STAILQ_FOREACH(feat_reg, &feature_list, next_feature) {
+		if (!feat_reg->runs_after && !feat_reg->runs_before)
+			continue;
+
+		if ((feat_reg->runs_after && !feat_reg->runs_before) ||
+		    (!feat_reg->runs_after && feat_reg->runs_before))
+			continue;
+
+		if (feature_registration_validate(feat_reg, __func__, __LINE__, 1, 0) < 0)
+			continue;
+
+		feat_reg->feature_node_id = feat_reg->feature_node->id;
+
+		rc = rte_graph_feature_add(feat_reg);
+
+		if (rc < 0)
+			goto arc_cleanup;
+	}
+
+	return 0;
+
+arc_cleanup:
+	rte_graph_feature_arc_cleanup();
+
+	return rc;
+}
+
+int
+rte_graph_feature_arc_create(struct rte_graph_feature_arc_register *reg,
+			     rte_graph_feature_arc_t *_arc)
+{
+	rte_graph_feature_arc_main_t *dfm = NULL;
+	struct rte_graph_feature_arc *arc = NULL;
+	uint16_t first_feat_off, fdata_off;
+	const struct rte_memzone *mz = NULL;
+	uint16_t iter, arc_index;
+	uint32_t feat_sz = 0;
+	size_t sz;
+
+	if (arc_registration_validate(reg, __func__, __LINE__) < 0)
+		return -1;
+
+	if (!reg->max_features)
+		graph_err("Zero features found for arc \"%s\" create",
+			  reg->arc_name);
+
+	if (!__rte_graph_feature_arc_main) {
+		mz = rte_memzone_lookup(FEATURE_ARC_MEMZONE_NAME);
+		if (mz) {
+			__rte_graph_feature_arc_main = mz->addr;
+		} else {
+			graph_err("Call to rte_graph_feature_arc_init() API missing");
+			return -1;
+		}
+	}
+
+	/* See if arc memory is already created */
+	mz = rte_memzone_lookup(reg->arc_name);
+	if (mz) {
+		graph_warn("Feature arc %s already created", reg->arc_name);
+		arc = mz->addr;
+		if (_arc)
+			*_arc = arc->feature_arc_index;
+
+		arc->process_ref_count++;
+
+		return 0;
+	}
+
+	dfm = __rte_graph_feature_arc_main;
+
+	/* threshold check */
+	if (dfm->num_feature_arcs > (dfm->max_feature_arcs - 1))
+		SET_ERR_JMP(EAGAIN, arc_create_err,
+			    "%s: max number (%u) of feature arcs reached",
+			    reg->arc_name, dfm->max_feature_arcs);
+
+	/* Find the free slot for feature arc */
+	for (iter = 0; iter < dfm->max_feature_arcs; iter++) {
+		if (dfm->feature_arcs[iter] == GRAPH_FEATURE_ARC_INITIALIZER)
+			break;
+	}
+	arc_index = iter;
+
+	if (arc_index >= dfm->max_feature_arcs) {
+		graph_err("No free slot found for num_feature_arc");
+		return -1;
+	}
+
+	/* This should not happen */
+	if (dfm->feature_arcs[arc_index] != GRAPH_FEATURE_ARC_INITIALIZER) {
+		graph_err("Free arc_index: %u is not found free: %p",
+			  arc_index, (void *)dfm->feature_arcs[arc_index]);
+		return -1;
+	}
+
+	/* Calculate size of feature arc */
+	feature_arc_reg_calc_size(reg, &sz, &first_feat_off, &fdata_off, &feat_sz);
+
+	mz = rte_memzone_reserve(reg->arc_name, sz, SOCKET_ID_ANY, 0);
+
+	if (!mz) {
+		graph_err("memzone reserve failed for arc: %s of size: %lu",
+			  reg->arc_name, sz);
+		return -1;
+	}
+
+	arc = mz->addr;
+
+	memset(arc, 0, sz);
+
+	arc->feature_bit_mask_by_index = rte_malloc(reg->arc_name,
+						    sizeof(uint64_t) * reg->max_indexes, 0);
+
+	if (!arc->feature_bit_mask_by_index) {
+		graph_err("%s: rte_malloc failed for feature_bit_mask_alloc", reg->arc_name);
+		rte_memzone_free(mz);
+		return -1;
+	}
+
+	memset(arc->feature_bit_mask_by_index, 0, sizeof(uint64_t) * reg->max_indexes);
+
+	/* override process function with start_node */
+	if (node_override_process_func(reg->start_node->id, reg->start_node_feature_process_fn)) {
+		graph_err("node_override_process_func failed for %s", reg->start_node->name);
+		rte_free(arc->feature_bit_mask_by_index);
+		rte_memzone_free(mz);
+		return -1;
+	}
+	feat_dbg("arc-%s: node-%s process() overridden with %p",
+		  reg->arc_name, reg->start_node->name,
+		  reg->start_node_feature_process_fn);
+
+	/* Initialize rte_graph port group fixed variables */
+	STAILQ_INIT(&arc->all_features);
+	rte_strscpy(arc->feature_arc_name, reg->arc_name, RTE_GRAPH_FEATURE_ARC_NAMELEN - 1);
+	arc->feature_arc_main = (void *)dfm;
+	arc->start_node = reg->start_node;
+	memcpy(&arc->end_feature, reg->end_feature, sizeof(arc->end_feature));
+	arc->arc_start_process = reg->start_node_feature_process_fn;
+	arc->feature_arc_index = arc_index;
+	arc->arc_size = sz;
+
+	/* reset fast path arc variables */
+	arc->max_features = reg->max_features;
+	arc->max_indexes = reg->max_indexes;
+	arc->fp_first_feature_offset = first_feat_off;
+	arc->fp_feature_data_offset = fdata_off;
+	arc->fp_feature_size = feat_sz;
+
+	arc->process_ref_count++;
+
+	feature_arc_data_reset(arc);
+
+	dfm->feature_arcs[arc->feature_arc_index] = (uintptr_t)arc;
+	dfm->num_feature_arcs++;
+
+	if (_arc)
+		*_arc = (rte_graph_feature_arc_t)arc_index;
+
+	feat_dbg("Feature arc %s[%p] created with max_features: %u and indexes: %u",
+		 arc->feature_arc_name, (void *)arc, arc->max_features, arc->max_indexes);
+
+	return 0;
+
+arc_create_err:
+	return -1;
+}
+
+int
+rte_graph_feature_add(struct rte_graph_feature_register *freg)
+{
+	struct rte_graph_feature_node_list *after_finfo = NULL, *before_finfo = NULL;
+	struct rte_graph_feature_node_list *temp = NULL, *finfo = NULL;
+	char feature_name[3 * RTE_GRAPH_FEATURE_ARC_NAMELEN];
+	const char *runs_after = NULL, *runs_before = NULL;
+	struct rte_graph_feature_arc *arc = NULL;
+	uint32_t slot = UINT32_MAX, add_flag;
+	rte_graph_feature_arc_t _arc;
+	uint32_t num_features = 0;
+	const char *nodename = NULL;
+	rte_edge_t edge = -1;
+	int rc = 0;
+
+	if (feature_registration_validate(freg, __func__, __LINE__, 0, 1) < 0)
+		return -1;
+
+	/* arc is valid */
+	if (rte_graph_feature_arc_lookup_by_name(freg->arc_name, &_arc)) {
+		graph_err("%s_add: feature arc %s not found",
+			  freg->feature_name, freg->arc_name);
+		return -1;
+	}
+
+	if (feature_arc_sanity(_arc)) {
+		graph_err("invalid feature arc: 0x%x", _arc);
+		return -1;
+	}
+
+	arc = rte_graph_feature_arc_get(_arc);
+
+	if (arc->runtime_enabled_features) {
+		graph_err("adding features after enabling any one of them is not supported");
+		return -1;
+	}
+
+	/* When application calls rte_graph_feature_add() directly*/
+	if (freg->feature_node_id == RTE_NODE_ID_INVALID) {
+		graph_err("%s/%s: Invalid feature_node_id set for %s",
+			  freg->arc_name, freg->feature_name, __func__);
+		return -1;
+	}
+
+	if ((freg->runs_after != NULL) && (freg->runs_before != NULL) &&
+	    (freg->runs_after == freg->runs_before)) {
+		graph_err("runs_after and runs_before cannot be same '%s:%s]", freg->runs_after,
+			  freg->runs_before);
+		return -1;
+	}
+
+	num_features = rte_graph_feature_arc_num_features(_arc);
+	nodeinfo_lkup_by_index(arc, num_features - 1, &temp, 0);
+
+	/* Check if feature is not added after end_feature */
+	if (num_features && (freg->runs_after != NULL) &&
+	    (strncmp(freg->runs_after, temp->feature_name,
+		     RTE_GRAPH_FEATURE_ARC_NAMELEN) == 0)) {
+		graph_err("Feature %s cannot be added after end_feature %s",
+			  freg->feature_name, freg->runs_after);
+		return -1;
+	}
+
+	if (!nodeinfo_add_lookup(arc, freg->feature_name, &finfo, &slot)) {
+		graph_err("%s/%s feature already added", arc->feature_arc_name, freg->feature_name);
+		return -1;
+	}
+
+	if (slot >= arc->max_features) {
+		graph_err("%s: Max features %u added to feature arc",
+			  arc->feature_arc_name, slot);
+		return -1;
+	}
+
+	if (freg->feature_node_id == arc->start_node->id) {
+		graph_err("%s/%s: Feature node and start node are same %u",
+			  freg->arc_name, freg->feature_name, freg->feature_node_id);
+		return -1;
+	}
+
+	nodename = rte_node_id_to_name(freg->feature_node_id);
+
+	feat_dbg("%s: adding feature node: %s at feature index: %u", arc->feature_arc_name,
+		 nodename, slot);
+
+	if (connect_graph_nodes(arc->start_node->id, freg->feature_node_id, &edge,
+				arc->feature_arc_name)) {
+		graph_err("unable to connect %s -> %s", arc->start_node->name, nodename);
+		return -1;
+	}
+
+	snprintf(feature_name, sizeof(feature_name), "%s-%s-finfo",
+		 arc->feature_arc_name, freg->feature_name);
+
+	finfo = rte_malloc(feature_name, sizeof(*finfo), 0);
+	if (!finfo) {
+		graph_err("%s/%s: rte_malloc failed", arc->feature_arc_name, freg->feature_name);
+		return -1;
+	}
+
+	memset(finfo, 0, sizeof(*finfo));
+
+	rte_strscpy(finfo->feature_name, freg->feature_name, RTE_GRAPH_FEATURE_ARC_NAMELEN - 1);
+	finfo->feature_arc = (void *)arc;
+	finfo->feature_node_id = freg->feature_node_id;
+	finfo->feature_node_process_fn = freg->feature_process_fn;
+	finfo->edge_to_this_feature = RTE_EDGE_ID_INVALID;
+	finfo->edge_to_last_feature = RTE_EDGE_ID_INVALID;
+	finfo->notifier_cb = freg->notifier_cb;
+
+	runs_before = freg->runs_before;
+	runs_after = freg->runs_after;
+
+	/*
+	 * if no constraints given and provided feature is not the first feature,
+	 * explicitly set "runs_before" as end_feature.
+	 *
+	 * Handles the case:
+	 * arc_create(f1);
+	 * add(f2, NULL, NULL);
+	 */
+	if (!runs_after && !runs_before && num_features)
+		runs_before = rte_graph_feature_arc_feature_to_name(_arc, num_features - 1);
+
+	/* Check for before and after constraints */
+	if (runs_before) {
+		/* runs_before sanity */
+		if (nodeinfo_lkup_by_name(arc, runs_before, &before_finfo, NULL))
+			SET_ERR_JMP(EINVAL, finfo_free,
+				     "Invalid before feature name: %s", runs_before);
+
+		if (!before_finfo)
+			SET_ERR_JMP(EINVAL, finfo_free,
+				     "runs_before %s does not exist", runs_before);
+
+		/*
+		 * Starting from 0 to runs_before, continue connecting edges
+		 */
+		add_flag = 1;
+		STAILQ_FOREACH(temp, &arc->all_features, next_feature) {
+			if (!add_flag)
+				/* Nodes after seeing "runs_before", finfo connects to temp*/
+				connect_graph_nodes(finfo->feature_node_id, temp->feature_node_id,
+						    NULL, arc->feature_arc_name);
+			/*
+			 * As soon as we see runs_before. stop adding edges
+			 */
+			if (!strncmp(temp->feature_name, runs_before, RTE_GRAPH_NAMESIZE)) {
+				if (!connect_graph_nodes(finfo->feature_node_id,
+							 temp->feature_node_id,
+							 &edge, arc->feature_arc_name))
+					add_flag = 0;
+			}
+
+			if (add_flag)
+				/* Nodes before seeing "run_before" are connected to finfo */
+				connect_graph_nodes(temp->feature_node_id, finfo->feature_node_id,
+						    NULL, arc->feature_arc_name);
+		}
+	}
+
+	if (runs_after) {
+		if (nodeinfo_lkup_by_name(arc, runs_after, &after_finfo, NULL))
+			SET_ERR_JMP(EINVAL, finfo_free,
+				     "Invalid after feature_name %s", runs_after);
+
+		if (!after_finfo)
+			SET_ERR_JMP(EINVAL, finfo_free,
+				     "runs_after %s does not exist", runs_after);
+
+		/* Starting from runs_after to end continue connecting edges */
+		add_flag = 0;
+		STAILQ_FOREACH(temp, &arc->all_features, next_feature) {
+			if (add_flag)
+				/* We have already seen runs_after now */
+				/* Add all features as next node to current feature*/
+				connect_graph_nodes(finfo->feature_node_id, temp->feature_node_id,
+						    NULL, arc->feature_arc_name);
+			else
+				/* Connect initial nodes to newly added node*/
+				connect_graph_nodes(temp->feature_node_id, finfo->feature_node_id,
+						    NULL, arc->feature_arc_name);
+
+			/* as soon as we see runs_after. start adding edges
+			 * from next iteration
+			 */
+			if (!strncmp(temp->feature_name, runs_after, RTE_GRAPH_NAMESIZE))
+				add_flag = 1;
+		}
+
+		/* add feature next to runs_after */
+		STAILQ_INSERT_AFTER(&arc->all_features, after_finfo, finfo, next_feature);
+	} else {
+		if (before_finfo) {
+			/* add finfo before "before_finfo" element in the list */
+			after_finfo = NULL;
+			STAILQ_FOREACH(temp, &arc->all_features, next_feature) {
+				if (before_finfo == temp) {
+					if (after_finfo)
+						STAILQ_INSERT_AFTER(&arc->all_features, after_finfo,
+								    finfo, next_feature);
+					else
+						STAILQ_INSERT_HEAD(&arc->all_features, finfo,
+								   next_feature);
+
+					/* override node process fn */
+					rc = node_override_process_func(finfo->feature_node_id,
+									freg->feature_process_fn);
+
+					if (rc < 0) {
+						graph_err("node_override_process_func failed for %s",
+							  freg->feature_name);
+						goto finfo_free;
+					}
+					return 0;
+				}
+				after_finfo = temp;
+			}
+		} else {
+			/* Very first feature just needs to be added to list */
+			STAILQ_INSERT_TAIL(&arc->all_features, finfo, next_feature);
+		}
+	}
+	/* override node_process_fn */
+	rc = node_override_process_func(finfo->feature_node_id, freg->feature_process_fn);
+	if (rc < 0) {
+		graph_err("node_override_process_func failed for %s", freg->feature_name);
+		goto finfo_free;
+	}
+
+	if (freg->feature_node)
+		feat_dbg("arc-%s: feature %s node %s process() overridden with %p",
+			  freg->arc_name, freg->feature_name, freg->feature_node->name,
+			  freg->feature_process_fn);
+	else
+		feat_dbg("arc-%s: feature %s nodeid %u process() overriding with %p",
+			  freg->arc_name, freg->feature_name,
+			  freg->feature_node_id, freg->feature_process_fn);
+
+	return 0;
+finfo_free:
+	rte_free(finfo);
+
+	return -1;
+}
+
+int
+rte_graph_feature_lookup(rte_graph_feature_arc_t _arc, const char *feature_name,
+			 rte_graph_feature_t *feat)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t slot;
+
+	if (!arc)
+		return -1;
+
+	if (!nodeinfo_lkup_by_name(arc, feature_name, &finfo, &slot)) {
+		*feat = (rte_graph_feature_t) slot;
+		return 0;
+	}
+
+	return -1;
+}
+
+static int
+feature_enable_disable_validate(rte_graph_feature_arc_t _arc, uint32_t index,
+				const char *feature_name,
+				int is_enable_disable, bool emit_logs)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t slot, last_end_feature;
+
+	if (!arc)
+		return -EINVAL;
+
+	/* validate _arc */
+	if (arc->feature_arc_main != __rte_graph_feature_arc_main) {
+		FEAT_COND_ERR(emit_logs, "invalid feature arc: 0x%x", _arc);
+		return -EINVAL;
+	}
+
+	/* validate index */
+	if (index >= arc->max_indexes) {
+		FEAT_COND_ERR(emit_logs, "%s: Invalid provided index: %u >= %u configured",
+			      arc->feature_arc_name, index, arc->max_indexes);
+		return -1;
+	}
+
+	/* validate feature_name is already added or not  */
+	if (nodeinfo_lkup_by_name(arc, feature_name, &finfo, &slot)) {
+		FEAT_COND_ERR(emit_logs, "%s: No feature %s added",
+			      arc->feature_arc_name, feature_name);
+		return -EINVAL;
+	}
+
+	if (!finfo) {
+		FEAT_COND_ERR(emit_logs, "%s: No feature: %s found to enable/disable",
+			      arc->feature_arc_name, feature_name);
+		return -EINVAL;
+	}
+
+	/* slot should be in valid range */
+	if (slot >= arc->max_features) {
+		FEAT_COND_ERR(emit_logs, "%s/%s: Invalid free slot %u(max=%u) for feature",
+			      arc->feature_arc_name, feature_name, slot, arc->max_features);
+		return -EINVAL;
+	}
+
+	/* slot should be in range of 0 - 63 */
+	if (slot > (GRAPH_FEATURE_MAX_NUM_PER_ARC - 1)) {
+		FEAT_COND_ERR(emit_logs, "%s/%s: Invalid slot: %u", arc->feature_arc_name,
+			      feature_name, slot);
+		return -EINVAL;
+	}
+
+	last_end_feature = rte_fls_u64(arc->feature_bit_mask_by_index[index]);
+	if (!last_end_feature) {
+		FEAT_COND_ERR(emit_logs, "%s: End feature not enabled", arc->feature_arc_name);
+		return -EINVAL;
+	}
+
+	/* if enabled feature is not end feature node and already enabled */
+	if (is_enable_disable &&
+	    (arc->feature_bit_mask_by_index[index] & RTE_BIT64(slot)) &&
+	    (slot != (last_end_feature - 1))) {
+		FEAT_COND_ERR(emit_logs, "%s: %s already enabled on index: %u",
+			      arc->feature_arc_name, feature_name, index);
+		return -1;
+	}
+
+	if (!is_enable_disable && !arc->runtime_enabled_features) {
+		FEAT_COND_ERR(emit_logs, "%s: No feature enabled to disable",
+			      arc->feature_arc_name);
+		return -1;
+	}
+
+	if (!is_enable_disable && !(arc->feature_bit_mask_by_index[index] & RTE_BIT64(slot))) {
+		FEAT_COND_ERR(emit_logs, "%s: %s not enabled in bitmask for index: %u",
+			      arc->feature_arc_name, feature_name, index);
+		return -1;
+	}
+
+	/* If no feature has been enabled, avoid extra sanity checks */
+	if (!arc->runtime_enabled_features)
+		return 0;
+
+	if (finfo->finfo_index != slot) {
+		FEAT_COND_ERR(emit_logs,
+			      "%s/%s: lookup slot mismatch for finfo idx: %u and lookup slot: %u",
+			      arc->feature_arc_name, feature_name, finfo->finfo_index, slot);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int
+refill_fastpath_data(struct rte_graph_feature_arc *arc, uint32_t feature_bit,
+		     uint16_t index /* array index */, int is_enable_disable)
+{
+	struct rte_graph_feature_data *gfd = NULL, *prev_gfd = NULL, *first = NULL;
+	struct rte_graph_feature_node_list *finfo = NULL, *prev_finfo = NULL;
+	RTE_ATOMIC(rte_graph_feature_t) * first_feat = NULL;
+	uint64_t bitmask = 0, prev_bitmask, next_bitmask;
+	uint32_t fi = 0, prev_fi = 0, next_fi = 0, cfi = 0;
+	bool update_first_feature = false;
+	rte_edge_t edge = UINT16_MAX;
+
+	if (is_enable_disable)
+		bitmask = RTE_BIT64(feature_bit);
+
+	/* set bit from (feature_bit + 1) to 64th bit */
+	next_bitmask = UINT64_MAX << (feature_bit + 1);
+
+	/* set bits from 0 to (feature_bit - 1) */
+	prev_bitmask = ((UINT64_MAX & ~next_bitmask) & ~(RTE_BIT64(feature_bit)));
+
+	next_bitmask &= arc->feature_bit_mask_by_index[index];
+	prev_bitmask &= arc->feature_bit_mask_by_index[index];
+
+	/* Set next bit set in next_bitmask */
+	if (rte_bsf64_safe(next_bitmask, &next_fi))
+		bitmask |= RTE_BIT64(next_fi);
+
+	/* Set prev bit set in prev_bitmask*/
+	prev_fi = rte_fls_u64(prev_bitmask);
+	if (prev_fi)
+		bitmask |= RTE_BIT64(prev_fi - 1);
+
+	/* for each feature set for index, set fast path data */
+	prev_gfd = NULL;
+	while (rte_bsf64_safe(bitmask, &fi)) {
+		gfd = rte_graph_feature_data_get(arc, fdata_from_feat(arc, fi, index));
+
+		RTE_VERIFY(!nodeinfo_lkup_by_index(arc, fi, &finfo, 1));
+
+		/* Reset next edge to point to last feature node so that packet can exit from arc */
+		rte_atomic_store_explicit(&gfd->next_edge, finfo->edge_to_last_feature,
+					  rte_memory_order_relaxed);
+
+		/*
+		 * Reset next feature data to last feature data
+		 */
+		rte_atomic_store_explicit(&gfd->next_feature_data,
+					  fdata_from_feat(arc, arc->max_features - 1, index),
+					  rte_memory_order_relaxed);
+
+		/* If previous feature_index was valid in last loop */
+		if (prev_gfd != NULL) {
+			/*
+			 * Get edge of previous feature node connecting
+			 * to this feature node
+			 */
+			RTE_VERIFY(!nodeinfo_lkup_by_index(arc, prev_fi, &prev_finfo, 1));
+
+			if (!get_existing_edge(arc->feature_arc_name,
+					      prev_finfo->feature_node_id,
+					      finfo->feature_node_id, &edge)) {
+				feat_dbg("\t[%s/index:%2u,cookie:%u]: (%u->%u)%s[%u] = %s",
+					 arc->feature_arc_name, index,
+					 gfd->app_cookie, prev_fi, fi,
+					 rte_node_id_to_name(prev_finfo->feature_node_id),
+					 edge, rte_node_id_to_name(finfo->feature_node_id));
+
+				rte_atomic_store_explicit(&prev_gfd->next_edge,
+							  edge,
+							  rte_memory_order_relaxed);
+
+				rte_atomic_store_explicit(&prev_gfd->next_feature_data,
+							  fdata_from_feat(arc, fi, index),
+							  rte_memory_order_relaxed);
+			} else {
+				/* Should not fail */
+				RTE_VERIFY(0);
+			}
+		}
+		/* On first feature
+		 * 1. Update fdata with next_edge from start_node to feature node
+		 * 2. Update first enabled feature in its index array
+		 */
+		if (rte_bsf64_safe(arc->feature_bit_mask_by_index[index], &cfi)) {
+			update_first_feature = (cfi == fi) ? true : false;
+
+			if (update_first_feature) {
+				feat_dbg("\t[%s/index:%2u,cookie:%u]: (->%u)%s[%u]=%s",
+					 arc->feature_arc_name, index,
+					 gfd->app_cookie, fi,
+					 arc->start_node->name, finfo->edge_to_this_feature,
+					 rte_node_id_to_name(finfo->feature_node_id));
+
+				first = __rte_graph_feature_data_get(arc, index);
+
+				/* add next edge into feature data
+				 * First set feature data then first feature memory
+				 */
+				rte_atomic_store_explicit(&first->next_edge,
+							  finfo->edge_to_this_feature,
+							  rte_memory_order_relaxed);
+
+				rte_atomic_store_explicit(&first->next_feature_data,
+							  fdata_from_feat(arc, fi, index),
+							  rte_memory_order_relaxed);
+
+				first_feat = graph_first_feature_ptr_get(arc, index);
+
+				rte_atomic_store_explicit(first_feat, fi,
+							  rte_memory_order_relaxed);
+			}
+		}
+		prev_fi = fi;
+		prev_gfd = gfd;
+		/* Clear current feature index */
+		bitmask &= ~RTE_BIT64(fi);
+	}
+
+	return 0;
+}
+
+int
+rte_graph_feature_enable(rte_graph_feature_arc_t _arc, uint32_t index,
+			 const char *feature_name, uint16_t app_cookie,
+			 struct rte_rcu_qsbr *qsbr)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	struct rte_graph_feature_node_list *finfo = NULL;
+	struct rte_graph_feature_data *gfd = NULL;
+	uint64_t bitmask;
+	uint32_t slot;
+
+	if (!arc) {
+		graph_err("Invalid feature arc: 0x%x", _arc);
+		return -1;
+	}
+
+	feat_dbg("%s: Enabling feature: %s for index: %u",
+		 arc->feature_arc_name, feature_name, index);
+
+	if ((!arc->runtime_enabled_features &&
+	    (prepare_feature_arc_before_first_enable(arc) < 0)))
+		return -1;
+
+	if (feature_enable_disable_validate(_arc, index, feature_name, 1 /* enable */, true))
+		return -1;
+
+	/** This should not fail as validate() has passed */
+	if (nodeinfo_lkup_by_name(arc, feature_name, &finfo, &slot))
+		RTE_VERIFY(0);
+
+	gfd = rte_graph_feature_data_get(arc, fdata_from_feat(arc, slot, index));
+
+	/* Set current app_cookie */
+	rte_atomic_store_explicit(&gfd->app_cookie, app_cookie, rte_memory_order_relaxed);
+
+	/* Set bitmask in control path bitmask */
+	rte_bit_relaxed_set64(graph_uint_cast(slot), &arc->feature_bit_mask_by_index[index]);
+
+	refill_fastpath_data(arc, slot, index, 1 /* enable */);
+
+	/* On very first feature enable instance */
+	if (!finfo->ref_count) {
+		/* If first time feature getting enabled
+		 */
+		bitmask = rte_atomic_load_explicit(&arc->fp_feature_enable_bitmask,
+						   rte_memory_order_relaxed);
+
+		bitmask |= RTE_BIT64(slot);
+
+		rte_atomic_store_explicit(&arc->fp_feature_enable_bitmask,
+					  bitmask, rte_memory_order_relaxed);
+	}
+
+	/* Slow path updates */
+	arc->runtime_enabled_features++;
+
+	/* Increase feature node info reference count */
+	finfo->ref_count++;
+
+	if (qsbr)
+		rte_rcu_qsbr_synchronize(qsbr, RTE_QSBR_THRID_INVALID);
+
+	if (finfo->notifier_cb)
+		finfo->notifier_cb(arc->feature_arc_name, finfo->feature_name, index,
+				   true /* enable */, gfd->app_cookie);
+
+	return 0;
+}
+
+int
+rte_graph_feature_disable(rte_graph_feature_arc_t _arc, uint32_t index, const char *feature_name,
+			  struct rte_rcu_qsbr *qsbr)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	struct rte_graph_feature_data *gfd = NULL, *dummy_gfd = NULL;
+	struct rte_graph_feature_node_list *finfo = NULL;
+	rte_graph_feature_data_t dummy_fdata;
+	uint32_t slot, last_end_feature;
+	uint64_t bitmask;
+
+	if (!arc) {
+		graph_err("Invalid feature arc: 0x%x", _arc);
+		return -1;
+	}
+	feat_dbg("%s: Disable feature: %s for index: %u",
+		 arc->feature_arc_name, feature_name, index);
+
+	if (feature_enable_disable_validate(_arc, index, feature_name, 0, true))
+		return -1;
+
+	if (nodeinfo_lkup_by_name(arc, feature_name, &finfo, &slot))
+		return -1;
+
+	/* If feature is not last feature, unset in control plane bitmask */
+	last_end_feature = rte_fls_u64(arc->feature_bit_mask_by_index[index]);
+	if (last_end_feature != arc->max_features) {
+		graph_err("%s/%s: No end feature enabled",
+			  arc->feature_arc_name, feature_name);
+		return -1;
+	}
+
+	last_end_feature = arc->max_features - 1;
+	if (slot != last_end_feature)
+		rte_bit_relaxed_clear64(graph_uint_cast(slot),
+					&arc->feature_bit_mask_by_index[index]);
+
+	/* we have allocated one extra feature data space. Get dummy feature data */
+	dummy_fdata = fdata_from_feat(arc, last_end_feature + 2, index);
+	dummy_gfd = __rte_graph_feature_data_get(arc, dummy_fdata);
+	gfd = rte_graph_feature_data_get(arc, fdata_from_feat(arc, slot, index));
+
+	/*
+	 * Packets may have reached to feature node which is getting disabled.
+	 * We want to steer those packets to last feature node so that they can
+	 * exit arc
+	 * - First, reset next_edge of dummy feature data to point to last_feature_node
+	 * - Secondly, reset next_feature_data of current feature getting disabled to dummy
+	 *   feature data
+	 */
+	rte_atomic_store_explicit(&dummy_gfd->next_edge, finfo->edge_to_last_feature,
+				  rte_memory_order_relaxed);
+	rte_atomic_store_explicit(&gfd->next_feature_data, dummy_fdata,
+				  rte_memory_order_relaxed);
+	rte_atomic_store_explicit(&dummy_gfd->next_feature_data, RTE_GRAPH_FEATURE_DATA_INVALID,
+				  rte_memory_order_relaxed);
+
+	/* Now we can unwire fast path*/
+	refill_fastpath_data(arc, slot, index, 0 /* disable */);
+
+	finfo->ref_count--;
+
+	/* When last feature is disabled */
+	if (!finfo->ref_count) {
+		/* If no feature enabled, reset feature in u64 fast path bitmask */
+		bitmask = rte_atomic_load_explicit(&arc->fp_feature_enable_bitmask,
+						   rte_memory_order_relaxed);
+		bitmask &= ~(RTE_BIT64(slot));
+		rte_atomic_store_explicit(&arc->fp_feature_enable_bitmask, bitmask,
+					  rte_memory_order_relaxed);
+	}
+
+	if (qsbr)
+		rte_rcu_qsbr_synchronize(qsbr, RTE_QSBR_THRID_INVALID);
+
+	/* Reset current gfd after rcu synchronization */
+	rte_atomic_store_explicit(&gfd->next_edge, RTE_GRAPH_FEATURE_DATA_INVALID,
+				  rte_memory_order_relaxed);
+
+	/* Call notifier cb with valid app_cookie */
+	if (finfo->notifier_cb)
+		finfo->notifier_cb(arc->feature_arc_name, finfo->feature_name, index,
+				   false /* disable */, gfd->app_cookie);
+
+	/* Reset app_cookie later after calling notifier_cb */
+	rte_atomic_store_explicit(&gfd->app_cookie, UINT16_MAX, rte_memory_order_relaxed);
+
+	arc->runtime_enabled_features--;
+
+	return 0;
+}
+
+int
+rte_graph_feature_arc_destroy(rte_graph_feature_arc_t _arc)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	rte_graph_feature_arc_main_t *dm = __rte_graph_feature_arc_main;
+	struct rte_graph_feature_node_list *node_info = NULL;
+	int iter;
+
+	if (!arc) {
+		graph_err("Invalid feature arc: 0x%x", _arc);
+		return -1;
+	}
+	arc->process_ref_count--;
+
+	if (arc->process_ref_count)
+		return arc->process_ref_count;
+
+	while (!STAILQ_EMPTY(&arc->all_features)) {
+		node_info = STAILQ_FIRST(&arc->all_features);
+		STAILQ_REMOVE_HEAD(&arc->all_features, next_feature);
+		if (node_info->notifier_cb) {
+			for (iter = 0; iter < arc->max_indexes; iter++) {
+				if (!(arc->feature_bit_mask_by_index[iter] &
+				    RTE_BIT64(node_info->finfo_index)))
+					continue;
+
+				node_info->notifier_cb(arc->feature_arc_name,
+						       node_info->feature_name,
+						       0, false /* disable */, 0);
+			}
+		}
+		rte_free(node_info);
+	}
+
+	dm->feature_arcs[arc->feature_arc_index] = GRAPH_FEATURE_ARC_INITIALIZER;
+
+	rte_free(arc->feature_bit_mask_by_index);
+
+	rte_memzone_free(rte_memzone_lookup(arc->feature_arc_name));
+
+	return 0;
+}
+
+int
+rte_graph_feature_arc_cleanup(void)
+{
+	rte_graph_feature_arc_main_t *dm = __rte_graph_feature_arc_main;
+	int dont_free = 0;
+	uint32_t iter;
+
+	if (!__rte_graph_feature_arc_main)
+		return -1;
+
+	for (iter = 0; iter < dm->max_feature_arcs; iter++) {
+		if (dm->feature_arcs[iter] == GRAPH_FEATURE_ARC_INITIALIZER)
+			continue;
+
+		if (rte_graph_feature_arc_destroy(dm->feature_arcs[iter]) > 0)
+			dont_free++;
+	}
+	if (!dont_free) {
+		rte_memzone_free(rte_memzone_lookup(FEATURE_ARC_MEMZONE_NAME));
+		__rte_graph_feature_arc_main = NULL;
+	}
+
+	return 0;
+}
+
+int
+rte_graph_feature_arc_lookup_by_name(const char *arc_name, rte_graph_feature_arc_t *_arc)
+{
+	struct rte_graph_feature_arc *arc = NULL;
+	const struct rte_memzone *mz = NULL;
+	rte_graph_feature_arc_main_t *dm;
+	uint32_t iter;
+
+	if (_arc)
+		*_arc = RTE_GRAPH_FEATURE_ARC_INITIALIZER;
+
+	if (!__rte_graph_feature_arc_main) {
+		mz = rte_memzone_lookup(FEATURE_ARC_MEMZONE_NAME);
+		if (mz)
+			__rte_graph_feature_arc_main = mz->addr;
+		else
+			return -1;
+	}
+
+	dm = __rte_graph_feature_arc_main;
+
+	for (iter = 0; iter < dm->max_feature_arcs; iter++) {
+		arc = rte_graph_feature_arc_get(iter);
+
+		if (!arc)
+			continue;
+
+		if ((strstr(arc->feature_arc_name, arc_name)) &&
+		    (strlen(arc->feature_arc_name) == strlen(arc_name))) {
+			if (_arc)
+				*_arc = arc->feature_arc_index;
+			return 0;
+		}
+	}
+
+	return -1;
+}
+
+uint32_t
+rte_graph_feature_arc_num_enabled_features(rte_graph_feature_arc_t _arc)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+
+	if (!arc) {
+		graph_err("Invalid feature arc: 0x%x", _arc);
+		return 0;
+	}
+
+	return arc->runtime_enabled_features;
+}
+
+uint32_t
+rte_graph_feature_arc_num_features(rte_graph_feature_arc_t _arc)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t count = 0;
+
+	if (!arc) {
+		graph_err("Invalid feature arc: 0x%x", _arc);
+		return 0;
+	}
+
+	STAILQ_FOREACH(finfo, &arc->all_features, next_feature)
+		count++;
+
+	return count;
+}
+
+char *
+rte_graph_feature_arc_feature_to_name(rte_graph_feature_arc_t _arc, rte_graph_feature_t feat)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t slot = feat;
+
+	if (!arc)
+		return NULL;
+
+	if (feat >= rte_graph_feature_arc_num_features(_arc)) {
+		graph_err("%s: feature %u does not exist", arc->feature_arc_name, feat);
+		return NULL;
+	}
+	if (!nodeinfo_lkup_by_index(arc, slot, &finfo, 0/* ignore sanity*/))
+		return finfo->feature_name;
+
+	return NULL;
+}
+
+int
+rte_graph_feature_arc_feature_to_node(rte_graph_feature_arc_t _arc, rte_graph_feature_t feat,
+				      rte_node_t *node)
+{
+	struct rte_graph_feature_arc *arc = rte_graph_feature_arc_get(_arc);
+	struct rte_graph_feature_node_list *finfo = NULL;
+	uint32_t slot = feat;
+
+	if (!arc)
+		return -1;
+
+	if (node)
+		*node = RTE_NODE_ID_INVALID;
+
+	if (feat >= rte_graph_feature_arc_num_features(_arc)) {
+		graph_err("%s: feature %u does not exist", arc->feature_arc_name, feat);
+		return -1;
+	}
+	if (!nodeinfo_lkup_by_index(arc, slot, &finfo, 0/* ignore sanity*/)) {
+		if (node)
+			*node = finfo->feature_node_id;
+		return 0;
+	}
+	return -1;
+}
+
+void __rte_graph_feature_arc_register(struct rte_graph_feature_arc_register *reg,
+				      const char *caller_name, int lineno)
+{
+	if (!reg) {
+		FEAT_ERR(caller_name, lineno, "NULL feature arc register");
+		return;
+	}
+
+	if (!reg->arc_name) {
+		FEAT_ERR(caller_name, lineno, "NULL feature arc name");
+		return;
+	}
+
+	if (!reg->max_indexes) {
+		FEAT_ERR(caller_name, lineno, "No indexes provided for arc %s",
+			 reg->arc_name);
+		return;
+	}
+
+	/* reg->max_features is calculated in rte_graph_feature_arc_init() */
+	if (!reg->start_node) {
+		FEAT_ERR(caller_name, lineno, "No start node provided for arc %s",
+			 reg->arc_name);
+		return;
+	}
+
+	if (!reg->start_node_feature_process_fn) {
+		FEAT_ERR(caller_name, lineno,
+			 "No start node process function provided for arc %s",
+			  reg->arc_name);
+		return;
+	}
+
+	if (!reg->end_feature) {
+		FEAT_ERR(caller_name, lineno,
+			 "No end feature provided for arc %s", reg->arc_name);
+		return;
+	}
+
+	/* No need to check end_feature->arc_name as it is implicit */
+	if (!reg->end_feature->feature_name) {
+		FEAT_ERR(caller_name, lineno,
+			 "No end feature provided for arc %s", reg->arc_name);
+		return;
+	}
+
+	if (!reg->end_feature->feature_process_fn) {
+		FEAT_ERR(caller_name, lineno,
+			 "No end feature process function provided for arc %s",
+			 reg->arc_name);
+		return;
+	}
+
+	if (!reg->end_feature->arc_name) {
+		FEAT_ERR(caller_name, lineno,
+			 "No end feature arc name provided for arc %s", reg->arc_name);
+		return;
+	}
+
+	STAILQ_INSERT_TAIL(&feature_arc_list, reg, next_arc);
+}
+
+void __rte_graph_feature_register(struct rte_graph_feature_register *reg,
+				  const char *caller_name, int lineno)
+{
+	if (feature_registration_validate(reg, caller_name, lineno, 0, 0) < 0)
+		return;
+
+	/* Add to the feature_list*/
+	STAILQ_INSERT_TAIL(&feature_list, reg, next_feature);
+}
+
+uint32_t
+rte_graph_feature_arc_names_get(char *arc_names[])
+{
+	rte_graph_feature_arc_main_t *dm = __rte_graph_feature_arc_main;
+	struct rte_graph_feature_arc *arc = NULL;
+	uint32_t count, num_arcs;
+
+	if (!__rte_graph_feature_arc_main)
+		return 0;
+
+	for (count = 0, num_arcs = 0; count < dm->max_feature_arcs; count++)
+		if (dm->feature_arcs[count] != GRAPH_FEATURE_ARC_INITIALIZER)
+			num_arcs++;
+
+	if (!num_arcs)
+		return 0;
+
+	if (!arc_names)
+		return sizeof(char *) * num_arcs;
+
+	for (count = 0, num_arcs = 0; count < dm->max_feature_arcs; count++) {
+		if (dm->feature_arcs[count] != GRAPH_FEATURE_ARC_INITIALIZER) {
+			arc = rte_graph_feature_arc_get(count);
+			arc_names[num_arcs] = arc->feature_arc_name;
+			num_arcs++;
+		}
+	}
+	return num_arcs;
+}

--- a/lib/graph/graph_feature_nodes.h
+++ b/lib/graph/graph_feature_nodes.h
@@ -1,0 +1,109 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+
+#include <rte_graph_feature_arc_worker.h>
+
+struct graph_interim_node_ctx {
+	uint16_t last_index;
+};
+
+#define FEATURE_INTERIM_NODE_LAST_NEXT_INDEX(ctx) \
+	(((struct graph_interim_node_ctx *)ctx)->last_index)
+
+static int
+feature_arc_interim_node_init(const struct rte_graph *graph, struct rte_node *node)
+{
+
+	RTE_SET_USED(graph);
+
+	/* original index is at 0th index*/
+	FEATURE_INTERIM_NODE_LAST_NEXT_INDEX(node->ctx) = 0;
+
+	return 0;
+}
+
+static __rte_always_inline int16_t
+feature_arc_node_process(struct rte_graph *graph, struct rte_node *node,
+			 void **objs, uint16_t nb_objs,
+			 const int is_start_node,
+			 const int is_feature_enabled)
+{
+	struct rte_graph_feature_arc *arc =
+		(struct rte_graph_feature_arc *)node->feature_arc_ptr;
+	int feat_dyn_off = rte_graph_feature_arc_mbuf_dynfield_offset_get();
+	struct rte_graph_feature_arc_mbuf_dynfields *mbfields = NULL;
+	void **to_next, **from;
+	uint16_t last_spec = 0;
+	rte_edge_t next_index;
+	struct rte_mbuf *mbuf;
+	uint16_t held = 0;
+	uint16_t next;
+	int is_feat;
+	int i;
+
+	RTE_SET_USED(is_start_node);
+
+	if (!is_feature_enabled) {
+		to_next = rte_node_next_stream_get(graph, node,
+						   0 /* original next_node is at index 0*/,
+						   nb_objs);
+		rte_node_next_stream_move(graph, node, 0);
+		return nb_objs;
+	}
+
+	/* Speculative next */
+	next_index = FEATURE_INTERIM_NODE_LAST_NEXT_INDEX(node->ctx);
+
+	from = objs;
+	to_next = rte_node_next_stream_get(graph, node, next_index, nb_objs);
+	for (i = 0; i < nb_objs; i++) {
+
+		mbuf = (struct rte_mbuf *)objs[i];
+
+		is_feat = 0;
+		next = 0;
+
+		/* Send mbuf to next enabled feature */
+		mbfields = rte_graph_feature_arc_mbuf_dynfields_get(mbuf, feat_dyn_off);
+
+		if (is_start_node)
+			is_feat = rte_graph_feature_data_first_feature_get(arc, mbuf->port,
+									   &mbfields->feature_data,
+									   &next);
+		else
+			is_feat = rte_graph_feature_data_next_feature_get(arc,
+									  &mbfields->feature_data,
+									  &next);
+
+		/* adjust next node only when feature is enabled, else next node is 0*/
+		is_feat = is_feat * node->base_arc_next_edge;
+		next -= is_feat;
+
+		if (unlikely(next_index != next)) {
+			/* Copy things successfully speculated till now */
+			rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
+			from += last_spec;
+			to_next += last_spec;
+			held += last_spec;
+			last_spec = 0;
+
+			rte_node_enqueue_x1(graph, node, next, from[0]);
+			from += 1;
+		} else {
+			last_spec += 1;
+		}
+	}
+	/* !!! Home run !!! */
+	if (likely(last_spec == nb_objs)) {
+		rte_node_next_stream_move(graph, node, next_index);
+		return nb_objs;
+	}
+	held += last_spec;
+	rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
+	rte_node_next_stream_put(graph, node, next_index, held);
+
+	FEATURE_INTERIM_NODE_LAST_NEXT_INDEX(node->ctx) = next;
+
+	return nb_objs;
+}

--- a/lib/graph/graph_populate.c
+++ b/lib/graph/graph_populate.c
@@ -11,6 +11,8 @@
 #include "graph_private.h"
 #include "graph_pcap_private.h"
 
+#include <rte_graph_feature_arc_worker.h>
+
 static size_t
 graph_fp_mem_calc_size(struct graph *graph)
 {
@@ -76,6 +78,7 @@ graph_nodes_populate(struct graph *_graph)
 	rte_graph_off_t xstat_off = _graph->xstats_start;
 	rte_graph_off_t off = _graph->nodes_start;
 	struct rte_graph *graph = _graph->graph;
+	rte_graph_feature_arc_t arc_handle;
 	struct graph_node *graph_node;
 	rte_edge_t count, nb_edges;
 	const char *parent;
@@ -97,6 +100,16 @@ graph_nodes_populate(struct graph *_graph)
 			parent = rte_node_id_to_name(pid);
 			memcpy(node->parent, parent, RTE_GRAPH_NAMESIZE);
 		}
+		if ((graph_node->node->finfo.flags & NODE_F_ARC) ||
+		    (graph_node->node->finfo.flags & NODE_F_ARC_INTERIM_NODE))
+			if (rte_graph_feature_arc_lookup_by_name(graph_node->node->finfo.arc_name,
+								 &arc_handle) == 0) {
+				node->feature_arc_ptr =
+					(void *)rte_graph_feature_arc_get(arc_handle);
+				node->base_arc_next_edge =
+					graph_node->node->finfo.fp_adjust_index;
+			}
+
 		node->id = graph_node->node->id;
 		node->parent_id = pid;
 		node->dispatch.lcore_id = graph_node->node->lcore_id;

--- a/lib/graph/graph_private.h
+++ b/lib/graph/graph_private.h
@@ -24,6 +24,10 @@ extern int rte_graph_logtype;
 	RTE_LOG_LINE_PREFIX(level, GRAPH,                                      \
 		"%s():%u ", __func__ RTE_LOG_COMMA __LINE__, __VA_ARGS__)
 
+#define GRAPH_LOG2(level, _fname, _linenum, ...)                               \
+	RTE_LOG_LINE_PREFIX(level, GRAPH,                                      \
+		"%s():%u ", _fname RTE_LOG_COMMA _linenum, __VA_ARGS__)
+
 #define graph_err(...) GRAPH_LOG(ERR, __VA_ARGS__)
 #define graph_warn(...) GRAPH_LOG(WARNING, __VA_ARGS__)
 #define graph_info(...) GRAPH_LOG(INFO, __VA_ARGS__)

--- a/lib/graph/graph_private.h
+++ b/lib/graph/graph_private.h
@@ -51,6 +51,29 @@ extern int rte_graph_logtype;
 /**
  * @internal
  *
+ * Enum to be set in feature_info.flags
+ */
+#define NODE_F_ARC                      0x1
+#define NODE_F_ARC_START_NODE           0x2
+#define NODE_F_ARC_INTERIM_NODE         0x4
+#define NODE_F_ARC_REVISITED            0x8
+
+/**
+ * @internal
+ *
+ * Structure that holds the node feature arc information
+ */
+struct feature_info {
+	uint32_t flags;      /** Internal node feature flags */
+	int first_arc_enabled_next_index; /**< Next node Index of first arc enabled node. */
+	int fp_adjust_index; /**< Index of the node to adjust the fast path. */
+	int num_feature_nodes; /**< Number of feature nodes. */
+	char arc_name[2 * RTE_NODE_NAMESIZE]; /**< Name of the arc node. */
+};
+
+/**
+ * @internal
+ *
  * Structure that holds node internal data.
  */
 struct node {
@@ -64,6 +87,7 @@ struct node {
 	rte_node_fini_t fini;	      /**< Node fini function. */
 	rte_node_t id;		      /**< Allocated identifier for the node. */
 	rte_node_t parent_id;	      /**< Parent node identifier. */
+	struct feature_info finfo; /**< Node feature information. */
 	rte_edge_t nb_edges;	      /**< Number of edges from this node. */
 	struct rte_node_xstats *xstats;	      /**< Node specific xstats. */
 	char next_nodes[][RTE_NODE_NAMESIZE]; /**< Names of next nodes. */
@@ -211,7 +235,8 @@ struct node *node_from_name(const char *name);
  *   - 0: Success.
  *   - <0: Error
  */
-int node_override_process_func(rte_node_t id, rte_node_process_t process);
+int node_override_process_func(rte_node_t id, rte_node_process_t process, bool is_start_node,
+			       const char *arc_name);
 
 /* Graph list functions */
 STAILQ_HEAD(graph_head, graph);

--- a/lib/graph/meson.build
+++ b/lib/graph/meson.build
@@ -15,14 +15,16 @@ sources = files(
         'graph_stats.c',
         'graph_populate.c',
         'graph_pcap.c',
+        'graph_feature_arc.c',
         'rte_graph_worker.c',
         'rte_graph_model_mcore_dispatch.c',
 )
 headers = files('rte_graph.h', 'rte_graph_worker.h')
+headers += files('rte_graph_feature_arc.h', 'rte_graph_feature_arc_worker.h')
 indirect_headers += files(
         'rte_graph_model_mcore_dispatch.h',
         'rte_graph_model_rtc.h',
         'rte_graph_worker_common.h',
 )
 
-deps += ['eal', 'pcapng', 'mempool', 'ring']
+deps += ['eal', 'pcapng', 'mempool', 'ring', 'rcu']

--- a/lib/graph/node.c
+++ b/lib/graph/node.c
@@ -421,16 +421,21 @@ rte_node_max_count(void)
 }
 
 int
-node_override_process_func(rte_node_t id, rte_node_process_t process)
+node_override_process_func(rte_node_t id, rte_node_process_t process, bool is_start_node,
+			   const char *arc_name)
 {
 	struct node *node;
 
+	RTE_SET_USED(process);
 	NODE_ID_CHECK(id);
 	graph_spinlock_lock();
 
 	STAILQ_FOREACH(node, &node_list, next) {
 		if (node->id == id) {
-			node->process = process;
+			rte_strscpy(node->finfo.arc_name, arc_name, RTE_NODE_NAMESIZE);
+			node->finfo.flags |= NODE_F_ARC;
+			if (is_start_node)
+				node->finfo.flags |= NODE_F_ARC_START_NODE;
 			graph_spinlock_unlock();
 			return 0;
 		}

--- a/lib/graph/rte_graph.h
+++ b/lib/graph/rte_graph.h
@@ -161,6 +161,7 @@ struct rte_graph_param {
 	/**< Array of node patterns based on shell pattern. */
 
 	bool pcap_enable; /**< Pcap enable. */
+	bool feature_arc_enable; /**< feature arc enable. */
 	uint64_t num_pkt_to_capture; /**< Number of packets to capture. */
 	char *pcap_filename; /**< Filename in which packets to be captured.*/
 

--- a/lib/graph/rte_graph_feature_arc.h
+++ b/lib/graph/rte_graph_feature_arc.h
@@ -1,0 +1,579 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+
+#ifndef _RTE_GRAPH_FEATURE_ARC_H_
+#define _RTE_GRAPH_FEATURE_ARC_H_
+
+#include <assert.h>
+#include <errno.h>
+#include <signal.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rte_common.h>
+#include <rte_compat.h>
+#include <rte_debug.h>
+#include <rte_graph.h>
+#include <rte_rcu_qsbr.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file
+ *
+ * rte_graph_feature_arc.h
+ *
+ * Define APIs and structures/variables with respect to feature arc
+ *
+ * - Feature arc(s)
+ * - Feature(s)
+ *
+ * In a typical network stack, often a protocol must be first enabled in
+ * control plane before any packet is steered for its processing in the
+ * dataplane. For eg: incoming IPv4 packets are sent to the routing sub-system
+ * only after a valid IPv4 address is assigned to the received interface. In
+ * other words, often packets received on an interface need to be steered
+ * to protocol not based on the packet content but based on whether the
+ * protocol is configured on the interface or not.
+ *
+ * Protocols can be enabled/disabled multiple times at runtime in the control
+ * plane and this extremely affects dataplane design.
+ *
+ * When more than one protocol is present at a networking layer (say
+ * IPv4, IPtables, IPsec etc), it becomes imperative to steer packets (in
+ * dataplane) across each protocol processing in a defined sequential order. In
+ * ingress direction, stack decides to perform IPsec decryption first before IP
+ * validation while in egress direction IPsec encryption is performed after IP
+ * lookup/rewrite. In the case of IPtables, users can enable rules in any protocol
+ * order i.e. pre-routing or post-routing etc. This implies that protocols are
+ * configured differently at each networking layer and in each traffic
+ * direction.
+ *
+ * A feature arc represents an ordered list of features/protocols nodes at the
+ * given networking layer and in a given direction. It provides a high level
+ * abstraction to enable/disable features on an index at runtime and provide a
+ * mechanism to steer packets across these feature nodes in a generic manner.
+ * Here index corresponds to either interface index, route index, flow index or
+ * classification index etc. as it is deemed suitable to configure protocols at
+ * the networking layer. Some typical examples of protocols which are
+ * configured based on
+ *
+ * - Interface Index (like IPv4 VRF, Port mirroring, Port based IPsec etc)
+ * - Routes Index (like Route based IPsec etc)
+ * - Flow index (like Software defined networking etc)
+ * - Classification Index (like ACL, Virtual switching etc)
+ *
+ * Feature arc also provides a way to steer packets from in-built DPDK *feature
+ * nodes* to out-of-tree *feature nodes* and vice-versa without any code
+ * changes required in in-built node's fast path functions. This way it allows
+ * application to override default packet path defined by in-built DPDK nodes.
+ *
+ * Features enabled on one index may not be enabled on another index hence
+ * packets received on an interface "X" should be treated independently from
+ * packets received on interface "Y".
+ *
+ * A given feature might consume packet (if it's configured to consume) or may
+ * forward it to next enabled feature. For instance, "IPsec input" feature may
+ * consume/drop all packets with "Protect" policy action while all packets with
+ * policy action as "Bypass" may be forwarded to next enabled feature (with in
+ * same feature arc)
+ *
+ * A feature arc in a graph is represented via *start_node* and *end_node*.
+ * Feature nodes are added between start_node and end_node. Packets enter
+ * feature arc traversal via start_node while they exits from end_node. Packets
+ * steering from start_node to feature nodes are controlled via
+ * via rte_graph_feature_enable()/rte_graph_feature_disable().
+ *
+ * This library facilitates rte graph based applications to steer packets in
+ * fast path to different feature nodes with-in a feature arc and support all
+ * functionalities described above
+ *
+ * In order to use feature-arc APIs, applications needs to do following in
+ * control plane:
+ * - Create feature arc object using RTE_GRAPH_FEATURE_ARC_REGISTER()
+ * - New feature nodes (In-built/Out-of-tree) can be added to an arc via
+ *   RTE_GRAPH_FEATURE_REGISTER(). RTE_GRAPH_FEATURE_REGISTER() has
+ *   "runs_after" and "runs_before" fields to specify protocol ordering
+ *   constraints.
+ * - Before calling rte_graph_create(), rte_graph_feature_arc_init() API must
+ *   be called. If rte_graph_feature_arc_init() is not called by application,
+ *   feature arc library has no affect.
+ * - Features can be enabled/disabled on any index at runtime via
+ *   rte_graph_feature_enable()/rte_graph_feature_disable()
+ * - Feature arc can be destroyed via rte_graph_feature_arc_destroy()
+ *
+ * Before enabling a feature, control plane might allocate certain resources
+ * (like VRF table for IP lookup or IPsec SA for inbound policy etc). A
+ * reference of allocated resource can be passed from control plane to
+ * dataplane via *app_cookie* argument in @ref rte_graph_feature_enable(). A
+ * corresponding dataplane API @ref rte_graph_feature_data_app_cookie_get() can
+ * be used to retrieve same cookie in fast path.
+ *
+ * When a feature is disabled, resources allocated during feature enable can be
+ * safely released via registering a callback in struct
+ * RTE_GRAPH_FEATURE_REGISTER()::notifier_cb. See fast path synchronization
+ * section below for more details.
+ *
+ * While *app_cookie* can be known corresponding to current feature node via
+ * @ref rte_graph_feature_data_app_cookie_get(), however if current feature
+ * node is not consuming packet it might want to send it to next enabled
+ * feature using:
+ *
+ * If current feature node is a:
+ * - start_node (via @ref rte_graph_feature_data_first_feature_get())
+ * - feature nodes added between start_node and end_node (via @ref
+ *   rte_graph_feature_data_next_feature_get())
+ * - end node (must not call any feature arc steering APIs) as from this node
+ *   packet exits feature arc
+ *
+ * Above APIs deals with fast path object: feature_data, which is unique for
+ * every index per feature with in a feature arc. It holds three data fields:
+ * next node edge, next enabled feature data and app_cookie.
+ *
+ * rte_mbuf carries [feature_data] into feature arc specific mbuf dynamic
+ * field (@ref rte_graph_feature_arc_mbuf_dynfield_offset_get())
+ *
+ * Fast path synchronization
+ * -------------------------
+ * Any feature enable/disable in control plane does not require stopping of
+ * worker cores.
+ *
+ * rte_graph_feature_enable()/rte_graph_feature_disable() APIs accepts
+ * (rte_rcu_qsbr *) as an argument to allow application releasing
+ * resources associated with features it may have allocated for per feature
+ * per interface.
+ *
+ * If RCU argument to rte_graph_feature_enable()/disable() is non-NULL:
+ *  - rte_rcu_qsbr_synchronize(rte_rcu_qsbr *) to synchronize all worker cores
+ *  - Calls RTE_GRAPH_FEATURE_REGISTER()->notifier_cb((), if set, and helps to
+ *  safely release resources associated feature
+ *
+ * It is application responsibility to pass valid RCU argument to APIs
+ *
+ * Constraints
+ * -----------
+ *  - Not more than 63 features can be added to a feature arc. There is no
+ *  limit to number of feature arcs i.e. number of
+ *  RTE_GRAPH_FEATURE_ARC_REGISTER()
+ *  - A feature node cannot be part of more than one arc due to performance
+ *  reason.
+ */
+
+/** Length of feature arc name */
+#define RTE_GRAPH_FEATURE_ARC_NAMELEN RTE_NODE_NAMESIZE
+
+/** Initializer values for ARC, Feature, Feature data */
+#define RTE_GRAPH_FEATURE_ARC_INITIALIZER ((rte_graph_feature_arc_t)UINT16_MAX)
+#define RTE_GRAPH_FEATURE_DATA_INVALID ((rte_graph_feature_data_t)UINT32_MAX)
+#define RTE_GRAPH_FEATURE_INVALID  ((rte_graph_feature_t)UINT8_MAX)
+
+/** rte_graph feature arc object */
+typedef uint16_t rte_graph_feature_arc_t;
+
+/** rte_graph feature object */
+typedef uint8_t rte_graph_feature_t;
+
+/** rte_graph feature data object */
+typedef uint32_t rte_graph_feature_data_t;
+
+/** feature notifier callback called when feature is enabled/disabled */
+typedef void (*rte_graph_feature_change_notifier_cb_t)(const char *arc_name,
+						       const char *feature_name,
+						       uint32_t index,
+						       bool enable_disable,
+						       uint16_t app_cookie);
+
+/**
+ *  Feature registration structure provided to
+ *  RTE_GRAPH_FEATURE_REGISTER()
+ */
+struct rte_graph_feature_register {
+	STAILQ_ENTRY(rte_graph_feature_register) next_feature;
+
+	/** Name of the arc which is registered either via
+	 * RTE_GRAPH_FEATURE_ARC_REGISTER() or via
+	 * rte_graph_feature_arc_create()
+	 */
+	const char *arc_name;
+
+	/* Name of the feature */
+	const char *feature_name;
+
+	/**
+	 * Node id of feature_node.
+	 *
+	 * Setting this field can be skipped if registering feature via
+	 * RTE_GRAPH_FEATURE_REGISTER()
+	 */
+	rte_node_t feature_node_id;
+
+	/**
+	 * Feature node process() function calling feature fast path APIs.
+	 *
+	 * If application calls rte_graph_feature_arc_init(), node->process()
+	 * provided in RTE_NODE_REGISTER() is overwritten by this
+	 * function.
+	 */
+	rte_node_process_t feature_process_fn;
+
+	/*
+	 * Pointer to Feature node registration
+	 *
+	 * Used when features are registered via
+	 * RTE_GRAPH_FEATURE_REGISTER().
+	 */
+	struct rte_node_register *feature_node;
+
+	/** Feature ordering constraints
+	 * runs_after: Name of the feature which must run before "this feature"
+	 * runs_before: Name of the feature which must run after "this feature"
+	 */
+	const char *runs_after;
+	const char *runs_before;
+
+	/**
+	 * Callback for notifying any change in feature enable/disable state
+	 */
+	rte_graph_feature_change_notifier_cb_t notifier_cb;
+};
+
+/** Feature arc registration structure */
+struct rte_graph_feature_arc_register {
+	STAILQ_ENTRY(rte_graph_feature_arc_register) next_arc;
+
+	/** Name of the feature arc */
+	const char *arc_name;
+
+	/**
+	 * Maximum number of features supported in this feature arc.
+	 *
+	 * This field can be skipped for feature arc registration via
+	 * RTE_GRAPH_FEATURE_ARC_REGISTER().
+	 *
+	 * API internally sets this field by calculating number of
+	 * RTE_GRAPH_FEATURE_REGISTER() for every arc registration via
+	 * RTE_GRAPH_FEATURE_ARC_REGISTER()
+	 */
+	uint32_t max_features;
+
+	/**
+	 * Maximum number of indexes supported in this feature arc
+	 *
+	 * Typically number of interfaces or ethdevs (For eg: RTE_MAX_ETHPORTS)
+	 */
+	uint32_t max_indexes;
+
+	/** Start node of this arc */
+	struct rte_node_register *start_node;
+
+	/**
+	 * Feature arc specific process() function for Start node.
+	 * If application calls rte_graph_feature_arc_init(),
+	 * start_node->process() is replaced by this function
+	 */
+	rte_node_process_t start_node_feature_process_fn;
+
+	/** End feature node registration */
+	struct rte_graph_feature_register *end_feature;
+};
+
+/** constructor to register feature to an arc */
+#define RTE_GRAPH_FEATURE_REGISTER(reg)                                                 \
+	RTE_INIT(__rte_graph_feature_register_##reg)                                    \
+	{                                                                               \
+		__rte_graph_feature_register(&reg, __func__, __LINE__);                 \
+	}
+
+/** constructor to register a feature arc */
+#define RTE_GRAPH_FEATURE_ARC_REGISTER(reg)                                             \
+		RTE_INIT(__rte_graph_feature_arc_register_##reg)                        \
+		{                                                                       \
+			__rte_graph_feature_arc_register(&reg, __func__, __LINE__);     \
+		}
+/**
+ * Initialize feature arc subsystem
+ *
+ * This API
+ * - Initializes feature arc module and alloc associated memory
+ * - creates feature arc for every RTE_GRAPH_FEATURE_ARC_REGISTER()
+ * - Add feature node to a feature arc for every RTE_GRAPH_FEATURE_REGISTER()
+ * - Replaces all RTE_NODE_REGISTER()->process() functions for
+ *   - Every start_node/end_node provided in arc registration
+ *   - Every feature node provided in feature registration
+ *
+ * @return
+ *  0: Success
+ * <0: Failure
+ */
+__rte_experimental
+int rte_graph_feature_arc_init(void);
+
+/**
+ * Create a feature arc.
+ *
+ * This API can be skipped if RTE_GRAPH_FEATURE_ARC_REGISTER() is used
+ *
+ * @param reg
+ *   Pointer to struct rte_graph_feature_arc_register
+ * @param[out] _arc
+ *  Feature arc object
+ *
+ * @return
+ *  0: Success
+ * <0: Failure
+ */
+__rte_experimental
+int rte_graph_feature_arc_create(struct rte_graph_feature_arc_register *reg,
+				 rte_graph_feature_arc_t *_arc);
+
+/**
+ * Get feature arc object with name
+ *
+ * @param arc_name
+ *   Feature arc name provided to successful @ref rte_graph_feature_arc_create
+ * @param[out] _arc
+ *   Feature arc object returned. Valid only when API returns SUCCESS
+ *
+ * @return
+ *  0: Success
+ * <0: Failure.
+ */
+__rte_experimental
+int rte_graph_feature_arc_lookup_by_name(const char *arc_name, rte_graph_feature_arc_t *_arc);
+
+/**
+ * Add a feature to already created feature arc.
+ *
+ * This API is not required in case RTE_GRAPH_FEATURE_REGISTER() is used
+ *
+ * @param feat_reg
+ * Pointer to struct rte_graph_feature_register
+ *
+ * <I> Must be called before rte_graph_create() </I>
+ * <I> rte_graph_feature_add() is not allowed after call to
+ * rte_graph_feature_enable() so all features must be added before they can be
+ * enabled </I>
+ *
+ * @return
+ *  0: Success
+ * <0: Failure
+ */
+__rte_experimental
+int rte_graph_feature_add(struct rte_graph_feature_register *feat_reg);
+
+/**
+ * Enable feature within a feature arc
+ *
+ * Must be called after @b rte_graph_create().
+ *
+ * @param _arc
+ *   Feature arc object returned by @ref rte_graph_feature_arc_create or @ref
+ *   rte_graph_feature_arc_lookup_by_name
+ * @param index
+ *   Application specific index. Can be corresponding to interface_id/port_id etc
+ * @param feature_name
+ *   Name of the node which is already added via @ref rte_graph_feature_add
+ * @param app_cookie
+ *   Application specific data which is retrieved in fast path
+ * @param qsbr
+ *   RCU QSBR object.  After enabling feature, API calls
+ *   rte_rcu_qsbr_synchronize() followed by call to struct
+ *   rte_graph_feature_register::notifier_cb(), if it is set, to notify feature
+ *   caller This object can be passed NULL as well if no RCU synchronization is
+ *   required
+ *
+ * @return
+ *  0: Success
+ * <0: Failure
+ */
+__rte_experimental
+int rte_graph_feature_enable(rte_graph_feature_arc_t _arc, uint32_t index, const
+			     char *feature_name, uint16_t app_cookie,
+			     struct rte_rcu_qsbr *qsbr);
+
+/**
+ * Disable already enabled feature within a feature arc
+ *
+ * Must be called after @b rte_graph_create(). API is *NOT* Thread-safe
+ *
+ * @param _arc
+ *   Feature arc object returned by @ref rte_graph_feature_arc_create or @ref
+ *   rte_graph_feature_arc_lookup_by_name
+ * @param index
+ *   Application specific index. Can be corresponding to interface_id/port_id etc
+ * @param feature_name
+ *   Name of the node which is already added via @ref rte_graph_feature_add
+ * @param qsbr
+ *   RCU QSBR object.  After disabling feature, API calls
+ *   rte_rcu_qsbr_synchronize() followed by call to struct
+ *   rte_graph_feature_register::notifier_cb(), if it is set, to notify feature
+ *   caller This object can be passed NULL as well if no RCU synchronization is
+ *   required
+ *
+ * @return
+ *  0: Success
+ * <0: Failure
+ */
+__rte_experimental
+int rte_graph_feature_disable(rte_graph_feature_arc_t _arc, uint32_t index,
+			      const char *feature_name, struct rte_rcu_qsbr *qsbr);
+
+/**
+ * Get rte_graph_feature_t object from feature name
+ *
+ * @param arc
+ *   Feature arc object returned by @ref rte_graph_feature_arc_create or @ref
+ *   rte_graph_feature_arc_lookup_by_name
+ * @param feature_name
+ *   Feature name provided to @ref rte_graph_feature_add
+ * @param[out] feature
+ *   Feature object
+ *
+ * @return
+ *  0: Success
+ * <0: Failure
+ */
+__rte_experimental
+int rte_graph_feature_lookup(rte_graph_feature_arc_t arc, const char *feature_name,
+			     rte_graph_feature_t *feature);
+
+/**
+ * Delete feature_arc object
+ *
+ * @param _arc
+ *   Feature arc object returned by @ref rte_graph_feature_arc_create or @ref
+ *   rte_graph_feature_arc_lookup_by_name
+ *
+ * @return
+ *  0: Success
+ * <0: Failure
+ */
+__rte_experimental
+int rte_graph_feature_arc_destroy(rte_graph_feature_arc_t _arc);
+
+/**
+ * Cleanup all feature arcs
+ *
+ * @return
+ *  0: Success
+ * <0: Failure
+ */
+__rte_experimental
+int rte_graph_feature_arc_cleanup(void);
+
+/**
+ * Slow path API to know how many features are added (NOT enabled) within a
+ * feature arc
+ *
+ * @param _arc
+ *  Feature arc object
+ *
+ * @return: Number of added features to arc
+ */
+__rte_experimental
+uint32_t rte_graph_feature_arc_num_features(rte_graph_feature_arc_t _arc);
+
+/**
+ * Slow path API to know how many features are currently enabled within a
+ * feature arc across all indexes. If a single feature is enabled on all interfaces,
+ * this API would return "number_of_interfaces" as count (but not "1")
+ *
+ * @param _arc
+ *  Feature arc object
+ *
+ * @return: Number of enabled features across all indexes
+ */
+__rte_experimental
+uint32_t rte_graph_feature_arc_num_enabled_features(rte_graph_feature_arc_t _arc);
+
+/**
+ * Slow path API to get feature node name from rte_graph_feature_t object
+ *
+ * @param _arc
+ *   Feature arc object
+ * @param feature
+ *   Feature object
+ *
+ * @return: Name of the feature node
+ */
+__rte_experimental
+char *rte_graph_feature_arc_feature_to_name(rte_graph_feature_arc_t _arc,
+					    rte_graph_feature_t feature);
+
+/**
+ * Slow path API to get corresponding rte_node_t from
+ * rte_graph_feature_t
+ *
+ * @param _arc
+ *   Feature arc object
+ * @param feature
+ *   Feature object
+ * @param[out] node
+ *   rte_node_t of feature node, Valid only when API returns SUCCESS
+ *
+ * @return: 0 on success, < 0 on failure
+ */
+__rte_experimental
+int
+rte_graph_feature_arc_feature_to_node(rte_graph_feature_arc_t _arc,
+				      rte_graph_feature_t feature,
+				      rte_node_t *node);
+
+/**
+ * Slow path API to dump valid feature arc names
+ *
+ *  @param[out] arc_names
+ *   Buffer to copy the arc names. The NULL value is allowed in that case,
+ * the function returns the size of the array that needs to be allocated.
+ *
+ * @return
+ *   When next_nodes == NULL, it returns the size of the array else
+ *  number of item copied.
+ */
+__rte_experimental
+uint32_t
+rte_graph_feature_arc_names_get(char *arc_names[]);
+
+/**
+ * @internal
+ *
+ * function declaration for registering arc
+ *
+ * @param reg
+ *      Pointer to struct rte_graph_feature_arc_register
+ *  @param caller_name
+ *      Name of the function which is calling this API
+ *  @param lineno
+ *      Line number of the function which is calling this API
+ */
+__rte_experimental
+void __rte_graph_feature_arc_register(struct rte_graph_feature_arc_register *reg,
+				      const char *caller_name, int lineno);
+
+/**
+ * @internal
+ *
+ * function declaration for registering feature
+ *
+ * @param reg
+ *      Pointer to struct rte_graph_feature_register
+ * @param caller_name
+ *      Name of the function which is calling this API
+ * @param lineno
+ *      Line number of the function which is calling this API
+ */
+__rte_experimental
+void __rte_graph_feature_register(struct rte_graph_feature_register *reg,
+				  const char *caller_name, int lineno);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/graph/rte_graph_feature_arc_worker.h
+++ b/lib/graph/rte_graph_feature_arc_worker.h
@@ -1,0 +1,574 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+
+#ifndef _RTE_GRAPH_FEATURE_ARC_WORKER_H_
+#define _RTE_GRAPH_FEATURE_ARC_WORKER_H_
+
+#include <stddef.h>
+#include <rte_graph_feature_arc.h>
+#include <rte_bitops.h>
+#include <rte_mbuf.h>
+#include <rte_mbuf_dyn.h>
+
+/**
+ * @file
+ *
+ * rte_graph_feature_arc_worker.h
+ *
+ * Defines fast path structure for feature arc
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @internal
+ *
+ * Slow path feature node info list
+ */
+struct rte_graph_feature_node_list {
+	/** Next feature */
+	STAILQ_ENTRY(rte_graph_feature_node_list) next_feature;
+
+	char feature_name[RTE_GRAPH_FEATURE_ARC_NAMELEN];
+
+	/** node id representing feature */
+	rte_node_t feature_node_id;
+
+	/** How many indexes/interfaces using this feature */
+	int32_t ref_count;
+
+	/**
+	 * feature arc process function overrides to feature node's original
+	 * process function
+	 */
+	rte_node_process_t feature_node_process_fn;
+
+	/** Callback for freeing application resources when */
+	rte_graph_feature_change_notifier_cb_t notifier_cb;
+
+	/* finfo_index in list. same as rte_graph_feature_t */
+	uint32_t finfo_index;
+
+	/** Back pointer to feature arc */
+	void *feature_arc;
+
+	/** rte_edge_t to this feature node from feature_arc->start_node */
+	rte_edge_t edge_to_this_feature;
+
+	/* rte_edge_t from this feature node to last feature node */
+	rte_edge_t edge_to_last_feature;
+};
+
+/**
+ * rte_graph Feature arc object
+ *
+ * Feature arc object holds control plane and fast path information for all
+ * features and all interface index information for steering packets across
+ * feature nodes
+ *
+ * Within a feature arc, only RTE_GRAPH_FEATURE_MAX_PER_ARC features can be
+ * added. If more features needs to be added, another feature arc can be
+ * created
+ *
+ * In fast path, rte_graph_feature_arc_t can be translated to (struct
+ * rte_graph_feature_arc *) via rte_graph_feature_arc_get(). Later is needed to
+ * add as an input argument to all fast path feature arc APIs
+ */
+struct __rte_cache_aligned rte_graph_feature_arc {
+	/** Slow path variables follows*/
+	RTE_MARKER slow_path_variables;
+
+	/** All feature lists */
+	STAILQ_HEAD(, rte_graph_feature_node_list) all_features;
+
+	/** feature arc name */
+	char feature_arc_name[RTE_GRAPH_FEATURE_ARC_NAMELEN];
+
+	/** control plane counter to track enabled features */
+	uint32_t runtime_enabled_features;
+
+	/** index in feature_arc_main */
+	uint16_t feature_arc_index;
+
+	/* process ref count to track feature_arc_destroy() */
+	uint8_t process_ref_count;
+
+	/** Back pointer to feature_arc_main */
+	void *feature_arc_main;
+
+	/** Arc's start/end node */
+	struct rte_node_register *start_node;
+	struct rte_graph_feature_register end_feature;
+
+	/* arc start process function */
+	rte_node_process_t arc_start_process;
+
+	/* total arc_size allocated */
+	size_t arc_size;
+
+	/** Slow path bit mask per feature per index */
+	uint64_t *feature_bit_mask_by_index;
+
+	/** Cache aligned fast path variables */
+	alignas(RTE_CACHE_LINE_SIZE) RTE_MARKER fast_path_variables;
+
+	/**
+	 * Quick fast path bitmask indicating if any feature enabled. Each bit
+	 * corresponds to single feature Helps in optimally process packets for
+	 * the case when features are added but not enabled
+	 */
+	RTE_ATOMIC(uint64_t) fp_feature_enable_bitmask;
+
+	/** maximum number of features supported by this arc
+	 *  Immutable during fast path
+	 */
+	uint16_t max_features;
+
+	/** maximum number of index supported by this arc
+	 *  Immutable during fast path
+	 */
+	uint16_t max_indexes;
+
+	/** arc + fp_first_feature_arr_offset
+	 * Immutable during fast path
+	 */
+	uint16_t fp_first_feature_offset;
+
+	/** arc + fp_feature_data_arr_offset
+	 * Immutable during fast path
+	 */
+	uint16_t fp_feature_data_offset;
+
+	/**
+	 * Size of each feature in fastpath.
+	 * ALIGN(sizeof(struct rte_graph_feature_data) * arc->max_indexes)
+	 * Immutable during fast path
+	 */
+	uint32_t fp_feature_size;
+
+	/**
+	 * Arc specific fast path data
+	 * It accommodates:
+	 *
+	 * 1. first enabled feature for every index
+	 * rte_graph_feature_t (fdata as shown below)
+	 *
+	 * +-------------------------+ <- cache_aligned
+	 * |  0th Index | 1st Index  |
+	 * +-------------------------+
+	 * |  feature0  | feature1   |
+	 * +-------------------------+
+	 *
+	 * 2. struct rte_graph_feature_data per index per feature
+	 *
+	 * feature0-> +----------------------------------------+ ^ <- cache_aligned
+	 *            |  struct rte_graph_feature_data[Index0] | |
+	 *            +----------------------------------------+ | fp_feature_size
+	 *            |  struct rte_graph_feature_data[Index1] | |
+	 * feature1-> +----------------------------------------+ v <- cache aligned
+	 *            |  struct rte_graph_feature_data[Index0] | ^
+	 *            +----------------------------------------+ | fp_feature_size
+	 *            |  struct rte_graph_feature_data[Index1] | |
+	 *            +----------------------------------------+ v
+	 *                    ...            ....
+	 *                    ...            ....
+	 */
+	RTE_MARKER8 fp_arc_data;
+};
+
+/**
+ * Feature arc main object
+ *
+ * Holds all feature arcs created by application
+ */
+typedef struct rte_feature_arc_main {
+	/** number of feature arcs created by application */
+	uint32_t num_feature_arcs;
+
+	/** max features arcs allowed */
+	uint32_t max_feature_arcs;
+
+	/** Pointer to all feature arcs */
+	uintptr_t feature_arcs[];
+} rte_graph_feature_arc_main_t;
+
+/**
+ *  Fast path feature data object
+ *
+ *  Used by fast path inline feature arc APIs
+ *  Corresponding to rte_graph_feature_data_t
+ *  It holds
+ *  - edge to reach to next feature node
+ *  - next_feature_data corresponding to next enabled feature
+ *  - app_cookie set by application in rte_graph_feature_enable()
+ */
+struct rte_graph_feature_data {
+	/** edge from this feature node to next enabled feature node */
+	RTE_ATOMIC(rte_edge_t) next_edge;
+
+	/**
+	 * app_cookie set by application in rte_graph_feature_enable() for
+	 * current feature data
+	 */
+	RTE_ATOMIC(uint16_t) app_cookie;
+
+	/** Next feature data from this feature data */
+	RTE_ATOMIC(rte_graph_feature_data_t) next_feature_data;
+};
+
+/** feature arc specific mbuf dynfield structure. */
+struct rte_graph_feature_arc_mbuf_dynfields {
+	/** each mbuf carries feature data */
+	rte_graph_feature_data_t feature_data;
+};
+
+/** Name of dynamic mbuf field offset registered in rte_graph_feature_arc_init() */
+#define RTE_GRAPH_FEATURE_ARC_DYNFIELD_NAME    "__rte_graph_feature_arc_mbuf_dynfield"
+
+/** log2(sizeof (struct rte_graph_feature_data)) */
+#define RTE_GRAPH_FEATURE_DATA_SIZE_LOG2	3
+
+/** Number of struct rte_graph_feature_data per feature*/
+#define RTE_GRAPH_FEATURE_DATA_NUM_PER_FEATURE(arc)				\
+	(arc->fp_feature_size >> RTE_GRAPH_FEATURE_DATA_SIZE_LOG2)
+
+/** Get rte_graph_feature_data_t from rte_graph_feature_t */
+#define RTE_GRAPH_FEATURE_TO_FEATURE_DATA(arc, feature, index)			\
+		((rte_graph_feature_data_t)					\
+		 ((RTE_GRAPH_FEATURE_DATA_NUM_PER_FEATURE(arc) * (feature + 1)) + (index)))
+
+/** extern variables */
+extern rte_graph_feature_arc_main_t *__rte_graph_feature_arc_main;
+extern int __rte_graph_feature_arc_mbuf_dyn_offset;
+
+/** get feature arc dynamic offset
+ *
+ * @return
+ *  offset to feature arc specific fields in mbuf
+ */
+__rte_experimental
+static __rte_always_inline int
+rte_graph_feature_arc_mbuf_dynfield_offset_get(void)
+{
+	return __rte_graph_feature_arc_mbuf_dyn_offset;
+}
+
+/**
+ * Get dynfield offset to feature arc specific fields in mbuf
+ *
+ * @param mbuf
+ *  Pointer to packet
+ * @param dyn_off
+ *  offset to feature arc specific fields in mbuf
+ *
+ * @return
+ *  NULL: On Failure
+ *  Non-NULL pointer on Success
+ */
+__rte_experimental
+static __rte_always_inline struct rte_graph_feature_arc_mbuf_dynfields *
+rte_graph_feature_arc_mbuf_dynfields_get(struct rte_mbuf *mbuf, const int dyn_off)
+{
+	return RTE_MBUF_DYNFIELD(mbuf, dyn_off,
+				 struct rte_graph_feature_arc_mbuf_dynfields *);
+}
+
+/**
+ * API to know if feature is valid or not
+ *
+ * @param feature
+ *  rte_graph_feature_t
+ *
+ * @return
+ *  1: If feature is valid
+ *  0: If feature is invalid
+ */
+__rte_experimental
+static __rte_always_inline int
+rte_graph_feature_is_valid(rte_graph_feature_t feature)
+{
+	return (feature != RTE_GRAPH_FEATURE_INVALID);
+}
+
+/**
+ * API to know if feature data is valid or not
+ *
+ * @param feature_data
+ *  rte_graph_feature_data_t
+ *
+ * @return
+ *  1: If feature data is valid
+ *  0: If feature data is invalid
+ */
+__rte_experimental
+static __rte_always_inline int
+rte_graph_feature_data_is_valid(rte_graph_feature_data_t feature_data)
+{
+	return (feature_data != RTE_GRAPH_FEATURE_DATA_INVALID);
+}
+
+/**
+ * Get pointer to feature arc object from rte_graph_feature_arc_t
+ *
+ * @param arc
+ *  feature arc
+ *
+ * @return
+ *  NULL: On Failure
+ *  Non-NULL pointer on Success
+ */
+__rte_experimental
+static __rte_always_inline struct rte_graph_feature_arc *
+rte_graph_feature_arc_get(rte_graph_feature_arc_t arc)
+{
+	rte_graph_feature_arc_main_t *fm = NULL;
+
+	fm = __rte_graph_feature_arc_main;
+
+	if (likely(fm != NULL && arc < fm->max_feature_arcs))
+		return (struct rte_graph_feature_arc *)fm->feature_arcs[arc];
+
+	return NULL;
+}
+
+/**
+ * Get rte_graph_feature_t from feature arc object without any checks
+ *
+ * @param arc
+ *  feature arc
+ * @param fdata
+ *  feature data object
+ *
+ * @return
+ *   Pointer to feature data object
+ */
+__rte_experimental
+static __rte_always_inline struct rte_graph_feature_data*
+__rte_graph_feature_data_get(struct rte_graph_feature_arc *arc,
+			     rte_graph_feature_data_t fdata)
+{
+	return ((struct rte_graph_feature_data *) ((uint8_t *)arc + arc->fp_feature_data_offset +
+						   (fdata << RTE_GRAPH_FEATURE_DATA_SIZE_LOG2)));
+}
+
+/**
+ * Get next edge from feature data pointer, without any check
+ *
+ * @param fdata
+ *  feature data object
+ *
+ * @return
+ *  next edge
+ */
+__rte_experimental
+static __rte_always_inline rte_edge_t
+__rte_graph_feature_data_edge_get(struct rte_graph_feature_data *fdata)
+{
+	return rte_atomic_load_explicit(&fdata->next_edge, rte_memory_order_relaxed);
+}
+
+/**
+ * Get app_cookie from feature data pointer, without any check
+ *
+ * @param fdata
+ *  feature data object
+ *
+ * @return
+ *  app_cookie set by caller in rte_graph_feature_enable() API
+ */
+__rte_experimental
+static __rte_always_inline uint16_t
+__rte_graph_feature_data_app_cookie_get(struct rte_graph_feature_data *fdata)
+{
+	return rte_atomic_load_explicit(&fdata->app_cookie, rte_memory_order_relaxed);
+}
+
+/**
+ * Get next_enabled_feature_data from pointer to feature data, without any check
+ *
+ * @param fdata
+ *  feature data object
+ *
+ * @return
+ *  next enabled feature data from this feature data
+ */
+__rte_experimental
+static __rte_always_inline rte_graph_feature_data_t
+__rte_graph_feature_data_next_feature_get(struct rte_graph_feature_data *fdata)
+{
+	return rte_atomic_load_explicit(&fdata->next_feature_data, rte_memory_order_relaxed);
+}
+
+/**
+ * Get app_cookie from feature data object with checks
+ *
+ * @param arc
+ *  feature arc
+ * @param fdata
+ *  feature data object
+ *
+ * @return
+ *  app_cookie set by caller in rte_graph_feature_enable() API
+ */
+__rte_experimental
+static __rte_always_inline uint16_t
+rte_graph_feature_data_app_cookie_get(struct rte_graph_feature_arc *arc,
+				      rte_graph_feature_data_t fdata)
+{
+	struct rte_graph_feature_data *fdata_obj = __rte_graph_feature_data_get(arc, fdata);
+
+	return __rte_graph_feature_data_app_cookie_get(fdata_obj);
+}
+
+/**
+ * Get next_enabled_feature_data from current feature data object with checks
+ *
+ * @param arc
+ *  feature arc
+ * @param[in|out] fdata
+ *  Pointer to feature data object
+ * @param[out] next_edge
+ *  next_edge from current feature to next enabled feature
+ *
+ * @return
+ *  1: if next feature enabled on index
+ *  0: if no feature is enabled on index
+ */
+__rte_experimental
+static __rte_always_inline int
+rte_graph_feature_data_next_feature_get(struct rte_graph_feature_arc *arc,
+					rte_graph_feature_data_t *fdata,
+					rte_edge_t *next_edge)
+{
+	struct rte_graph_feature_data *fdata_obj = __rte_graph_feature_data_get(arc, *fdata);
+
+	*fdata = __rte_graph_feature_data_next_feature_get(fdata_obj);
+	*next_edge = __rte_graph_feature_data_edge_get(fdata_obj);
+
+	return (rte_graph_feature_data_is_valid(*fdata));
+}
+
+/**
+ * Get struct rte_graph_feature_data from rte_graph_feature_dat_t
+ *
+ * @param arc
+ *   feature arc
+ * @param fdata
+ *  feature data object
+ *
+ * @return
+ *   NULL: On Failure
+ *   Non-NULL pointer on Success
+ */
+__rte_experimental
+static __rte_always_inline struct rte_graph_feature_data*
+rte_graph_feature_data_get(struct rte_graph_feature_arc *arc,
+			   rte_graph_feature_data_t fdata)
+{
+	if (unlikely(fdata > (RTE_GRAPH_FEATURE_TO_FEATURE_DATA(arc,
+								arc->max_features - 1,
+								arc->max_indexes - 1))))
+		return NULL;
+
+	return __rte_graph_feature_data_get(arc, fdata);
+}
+
+/**
+ * Get feature data corresponding to first enabled feature on index
+ * @param arc
+ *   feature arc
+ * @param index
+ *   Interface index
+ * @param[out] fdata
+ *  feature data object
+ * @param[out] edge
+ *  rte_edge object
+ *
+ * @return
+ *  1: if any feature enabled on index, return corresponding valid feature data
+ *  0: if no feature is enabled on index
+ */
+__rte_experimental
+static __rte_always_inline int
+rte_graph_feature_data_first_feature_get(struct rte_graph_feature_arc *arc,
+					 uint32_t index,
+					 rte_graph_feature_data_t *fdata,
+					 rte_edge_t *edge)
+{
+	struct rte_graph_feature_data *fdata_obj = NULL;
+	rte_graph_feature_t *feature = NULL;
+
+	*fdata = RTE_GRAPH_FEATURE_DATA_INVALID;
+
+	feature = (rte_graph_feature_t *)((uint8_t *)arc + arc->fp_first_feature_offset +
+					  (sizeof(rte_graph_feature_t) * index));
+
+	if (unlikely(rte_graph_feature_is_valid(*feature))) {
+		fdata_obj = __rte_graph_feature_data_get(arc, index);
+		*edge = __rte_graph_feature_data_edge_get(fdata_obj);
+		*fdata = __rte_graph_feature_data_next_feature_get(fdata_obj);
+		return 1;
+	}
+
+	return 0;
+}
+
+/**
+ * Fast path API to check if any feature enabled on a feature arc
+ * Typically from arc->start_node process function
+ *
+ * @param arc
+ *   Feature arc object
+ *
+ * @return
+ *  0: If no feature enabled
+ *  Non-Zero: Bitmask of features enabled.
+ *
+ */
+__rte_experimental
+static __rte_always_inline uint64_t
+rte_graph_feature_arc_is_any_feature_enabled(struct rte_graph_feature_arc *arc)
+{
+	return (rte_atomic_load_explicit(&arc->fp_feature_enable_bitmask,
+					 rte_memory_order_relaxed));
+}
+
+/**
+ * Prefetch feature arc fast path cache line
+ *
+ * @param arc
+ *   RTE_GRAPH feature arc object
+ */
+__rte_experimental
+static __rte_always_inline void
+rte_graph_feature_arc_prefetch(struct rte_graph_feature_arc *arc)
+{
+	rte_prefetch0((void *)arc->fast_path_variables);
+}
+
+/**
+ * Prefetch feature data related fast path cache line
+ *
+ * @param arc
+ *   RTE_GRAPH feature arc object
+ * @param fdata
+ *   Pointer to feature data object
+ */
+__rte_experimental
+static __rte_always_inline void
+rte_graph_feature_arc_feature_data_prefetch(struct rte_graph_feature_arc *arc,
+					    rte_graph_feature_data_t fdata)
+{
+	if (unlikely(fdata == RTE_GRAPH_FEATURE_DATA_INVALID))
+		return;
+
+	rte_prefetch0((void *)__rte_graph_feature_data_get(arc, fdata));
+}
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/lib/graph/rte_graph_worker_common.h
+++ b/lib/graph/rte_graph_worker_common.h
@@ -116,6 +116,8 @@ struct __rte_cache_aligned rte_node {
 	/** Fast path area cache line 1. */
 	alignas(RTE_CACHE_LINE_MIN_SIZE)
 	rte_graph_off_t xstat_off; /**< Offset to xstat counters. */
+	void *feature_arc_ptr; /**< Feature arc ptr, if enabled */
+	rte_edge_t base_arc_next_edge; /**< Next edge of first feature child */
 
 	/** Fast path area cache line 2. */
 	__extension__ struct __rte_cache_aligned {

--- a/lib/graph/version.map
+++ b/lib/graph/version.map
@@ -56,6 +56,26 @@ DPDK_25 {
 EXPERIMENTAL {
 	global:
 
+	# added in 25.03
+	__rte_graph_feature_arc_main;
+	__rte_graph_feature_arc_mbuf_dyn_offset;
+	__rte_graph_feature_arc_register;
+	__rte_graph_feature_register;
+	rte_graph_feature_arc_init;
+	rte_graph_feature_arc_create;
+	rte_graph_feature_arc_lookup_by_name;
+	rte_graph_feature_add;
+	rte_graph_feature_enable;
+	rte_graph_feature_disable;
+	rte_graph_feature_lookup;
+	rte_graph_feature_arc_destroy;
+	rte_graph_feature_arc_cleanup;
+	rte_graph_feature_arc_num_enabled_features;
+	rte_graph_feature_arc_num_features;
+	rte_graph_feature_arc_feature_to_name;
+	rte_graph_feature_arc_feature_to_node;
+	rte_graph_feature_arc_names_get;
+
 	# added in 24.11
 	rte_node_xstat_increment;
 };

--- a/lib/node/ethdev_ctrl.c
+++ b/lib/node/ethdev_ctrl.c
@@ -14,6 +14,7 @@
 #include "ethdev_tx_priv.h"
 #include "ip4_rewrite_priv.h"
 #include "ip6_rewrite_priv.h"
+#include "interface_tx_feature_priv.h"
 #include "node_private.h"
 
 static struct ethdev_ctrl {
@@ -24,6 +25,7 @@ int
 rte_node_eth_config(struct rte_node_ethdev_config *conf, uint16_t nb_confs,
 		    uint16_t nb_graphs)
 {
+	struct rte_node_register *if_tx_feature_node;
 	struct rte_node_register *ip4_rewrite_node;
 	struct rte_node_register *ip6_rewrite_node;
 	struct ethdev_tx_node_main *tx_node_data;
@@ -35,6 +37,7 @@ rte_node_eth_config(struct rte_node_ethdev_config *conf, uint16_t nb_confs,
 	int i, j, rc;
 	uint32_t id;
 
+	if_tx_feature_node = if_tx_feature_node_get();
 	ip4_rewrite_node = ip4_rewrite_node_get();
 	ip6_rewrite_node = ip6_rewrite_node_get();
 	tx_node_data = ethdev_tx_node_data_get();
@@ -125,6 +128,11 @@ rte_node_eth_config(struct rte_node_ethdev_config *conf, uint16_t nb_confs,
 		if (rc < 0)
 			return rc;
 
+		/* Add this tx port node to if_tx_feature_node */
+		rte_node_edge_update(if_tx_feature_node->id, RTE_EDGE_ID_INVALID,
+				     &next_nodes, 1);
+		rc = if_tx_feature_node_set_next(port_id,
+						 rte_node_edge_count(if_tx_feature_node->id) - 1);
 	}
 
 	ctrl.nb_graphs = nb_graphs;

--- a/lib/node/interface_tx_feature.c
+++ b/lib/node/interface_tx_feature.c
@@ -1,0 +1,133 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+
+#include <rte_ethdev.h>
+#include <rte_ether.h>
+#include <rte_graph_feature_arc_worker.h>
+#include <rte_malloc.h>
+
+#include "rte_node_ip4_api.h"
+#include "node_private.h"
+#include "interface_tx_feature_priv.h"
+
+#define IF_TX_FEATURE_LAST_NEXT_INDEX(ctx) \
+	(((struct if_tx_feature_node_ctx *)ctx)->last_index)
+/*
+ * @internal array for mapping port to next node index
+ */
+struct if_tx_feature_node_main  {
+	uint16_t next_index[RTE_MAX_ETHPORTS];
+};
+
+struct if_tx_feature_node_ctx {
+	uint16_t last_index;
+};
+
+static struct if_tx_feature_node_main *if_tx_feature_nm;
+
+int
+if_tx_feature_node_set_next(uint16_t port_id, uint16_t next_index)
+{
+	if (if_tx_feature_nm == NULL) {
+		if_tx_feature_nm = rte_zmalloc(
+			"if_tx_feature_nm", sizeof(struct if_tx_feature_node_main),
+			RTE_CACHE_LINE_SIZE);
+		if (if_tx_feature_nm == NULL)
+			return -ENOMEM;
+	}
+	if_tx_feature_nm->next_index[port_id] = next_index;
+
+	return 0;
+}
+
+static int
+if_tx_feature_node_init(const struct rte_graph *graph, struct rte_node *node)
+{
+	RTE_SET_USED(graph);
+
+	/* pkt_drop */
+	IF_TX_FEATURE_LAST_NEXT_INDEX(node->ctx) = 0;
+
+	return 0;
+}
+
+static uint16_t
+if_tx_feature_node_process(struct rte_graph *graph, struct rte_node *node,
+			   void **objs, uint16_t nb_objs)
+{
+	uint16_t held = 0, next;
+	void **to_next, **from;
+	uint16_t last_spec = 0;
+	rte_edge_t next_index;
+	struct rte_mbuf *mbuf;
+	int i;
+
+	/* Speculative next */
+	next_index = IF_TX_FEATURE_LAST_NEXT_INDEX(node->ctx);
+
+	from = objs;
+	to_next = rte_node_next_stream_get(graph, node, next_index, nb_objs);
+	for (i = 0; i < nb_objs; i++) {
+
+		mbuf = (struct rte_mbuf *)objs[i];
+
+		/* port-tx node starts from next edge 1*/
+		next = if_tx_feature_nm->next_index[mbuf->port];
+
+		if (unlikely(next_index != next)) {
+			/* Copy things successfully speculated till now */
+			rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
+			from += last_spec;
+			to_next += last_spec;
+			held += last_spec;
+			last_spec = 0;
+
+			rte_node_enqueue_x1(graph, node, next, from[0]);
+			from += 1;
+		} else {
+			last_spec += 1;
+		}
+	}
+	/* !!! Home run !!! */
+	if (likely(last_spec == nb_objs)) {
+		rte_node_next_stream_move(graph, node, next_index);
+		return nb_objs;
+	}
+	held += last_spec;
+	rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
+	rte_node_next_stream_put(graph, node, next_index, held);
+
+	IF_TX_FEATURE_LAST_NEXT_INDEX(node->ctx) = next;
+
+	return nb_objs;
+}
+
+static struct rte_node_register if_tx_feature_node = {
+	.process = if_tx_feature_node_process,
+	.init = if_tx_feature_node_init,
+	.name = "interface_tx",
+	.nb_edges = 1,
+	.next_nodes = {
+		[0] = "pkt_drop",
+	},
+};
+
+struct rte_node_register *
+if_tx_feature_node_get(void)
+{
+	return &if_tx_feature_node;
+}
+
+RTE_NODE_REGISTER(if_tx_feature_node);
+
+/* if_tx feature node */
+struct rte_graph_feature_register if_tx_feature = {
+	.feature_name = RTE_IP4_OUTPUT_END_FEATURE_NAME,
+	.arc_name = RTE_IP4_OUTPUT_FEATURE_ARC_NAME,
+	.feature_process_fn = if_tx_feature_node_process,
+	.feature_node = &if_tx_feature_node,
+};

--- a/lib/node/interface_tx_feature_priv.h
+++ b/lib/node/interface_tx_feature_priv.h
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+ * Copyright(C) 2025 Marvell International Ltd.
+ */
+#ifndef __INCLUDE_IF_TX_FEATURE_PRIV_H__
+#define __INCLUDE_IF_TX_FEATURE_PRIV_H__
+
+#include <rte_common.h>
+
+extern struct rte_graph_feature_register if_tx_feature;
+
+/**
+ * @internal
+ *
+ * Get the ipv4 rewrite node.
+ *
+ * @return
+ *   Pointer to the ipv4 rewrite node.
+ */
+struct rte_node_register *if_tx_feature_node_get(void);
+
+/**
+ * @internal
+ *
+ * Set the Edge index of a given port_id.
+ *
+ * @param port_id
+ *   Ethernet port identifier.
+ * @param next_index
+ *   Edge index of the Given Tx node.
+ */
+int if_tx_feature_node_set_next(uint16_t port_id, uint16_t next_index);
+
+#endif /* __INCLUDE_INTERFCE_TX_FEATURE_PRIV_H */

--- a/lib/node/ip4_rewrite.c
+++ b/lib/node/ip4_rewrite.c
@@ -6,6 +6,7 @@
 #include <rte_ether.h>
 #include <rte_graph.h>
 #include <rte_graph_worker.h>
+#include <rte_graph_feature_arc_worker.h>
 #include <rte_ip.h>
 #include <rte_malloc.h>
 #include <rte_vect.h>
@@ -14,15 +15,27 @@
 
 #include "ip4_rewrite_priv.h"
 #include "node_private.h"
+#include "interface_tx_feature_priv.h"
+
+#ifndef RTE_IP4_OUTPUT_ARC_INDEXES
+#define RTE_IP4_OUTPUT_ARC_INDEXES RTE_MAX_ETHPORTS
+#endif
 
 struct ip4_rewrite_node_ctx {
 	/* Dynamic offset to mbuf priv1 */
 	int mbuf_priv1_off;
+	/* Dynamic offset to feature arc field */
+	int arc_dyn_off;
 	/* Cached next index */
 	uint16_t next_index;
+	/* tx interface of last mbuf */
+	uint16_t last_tx_if;
+	/* Cached feature arc handle */
+	rte_graph_feature_arc_t output_feature_arc;
 };
 
 static struct ip4_rewrite_node_main *ip4_rewrite_nm;
+static int port_to_next_index_diff = -1;
 
 #define IP4_REWRITE_NODE_LAST_NEXT(ctx) \
 	(((struct ip4_rewrite_node_ctx *)ctx)->next_index)
@@ -30,16 +43,158 @@ static struct ip4_rewrite_node_main *ip4_rewrite_nm;
 #define IP4_REWRITE_NODE_PRIV1_OFF(ctx) \
 	(((struct ip4_rewrite_node_ctx *)ctx)->mbuf_priv1_off)
 
-static uint16_t
-ip4_rewrite_node_process(struct rte_graph *graph, struct rte_node *node,
-			 void **objs, uint16_t nb_objs)
+#define IP4_REWRITE_NODE_FEAT_OFF(ctx) \
+	(((struct ip4_rewrite_node_ctx *)ctx)->arc_dyn_off)
+
+#define IP4_REWRITE_NODE_OUTPUT_FEATURE_ARC(ctx) \
+	(((struct ip4_rewrite_node_ctx *)ctx)->output_feature_arc)
+
+#define IP4_REWRITE_NODE_LAST_TX_IF(ctx) \
+	(((struct ip4_rewrite_node_ctx *)ctx)->last_tx_if)
+
+static __rte_always_inline void
+check_output_feature_arc_x1(struct rte_graph_feature_arc *arc, uint16_t *tx_if,
+			    struct rte_mbuf *mbuf0, uint16_t *next0,
+			    uint16_t *last_next_index,
+			    rte_graph_feature_data_t *feature_data, const int dyn)
+{
+	struct rte_graph_feature_arc_mbuf_dynfields *d0 = NULL;
+	uint16_t port0;
+
+	/* make sure packets are not being sent to pkt_drop node */
+	if (likely(*next0 >= port_to_next_index_diff)) {
+
+		port0 = (*next0) - port_to_next_index_diff;
+
+		/* get pointer to feature arc mbuf */
+		d0 = rte_graph_feature_arc_mbuf_dynfields_get(mbuf0, dyn);
+
+		/* Check if last packet's tx port not same as current */
+		if (*tx_if != port0) {
+			if (rte_graph_feature_data_first_feature_get(arc, port0,
+								     &d0->feature_data,
+								     next0)) {
+				mbuf0->port = port0;
+				*last_next_index = *next0;
+			}
+			*tx_if = port0;
+			*feature_data = d0->feature_data;
+		} else {
+			if (rte_graph_feature_data_is_valid(*feature_data)) {
+				*next0 = *last_next_index;
+				mbuf0->port = port0;
+				d0->feature_data = *feature_data;
+			}
+		}
+	}
+}
+
+static __rte_always_inline void
+check_output_feature_arc_x4(struct rte_graph_feature_arc *arc, uint16_t *tx_if,
+			    struct rte_mbuf *mbuf0, struct rte_mbuf *mbuf1,
+			    struct rte_mbuf *mbuf2, struct rte_mbuf *mbuf3,
+			    uint16_t *next0, uint16_t *next1, uint16_t *next2,
+			    uint16_t *next3, uint16_t *last_next_index,
+			    rte_graph_feature_data_t *feature_data, const int dyn)
+{
+	struct rte_graph_feature_arc_mbuf_dynfields *d0 = NULL, *d1 = NULL, *d2 = NULL, *d3 = NULL;
+	uint16_t port0, port1, port2, port3;
+	uint16_t xor = 0;
+
+	/* get pointer to feature arc dyn field */
+	d0 = rte_graph_feature_arc_mbuf_dynfields_get(mbuf0, dyn);
+	d1 = rte_graph_feature_arc_mbuf_dynfields_get(mbuf1, dyn);
+	d2 = rte_graph_feature_arc_mbuf_dynfields_get(mbuf2, dyn);
+	d3 = rte_graph_feature_arc_mbuf_dynfields_get(mbuf3, dyn);
+
+	/*
+	 * Check if all four packets are going to same next_index/port
+	 */
+	xor = (*tx_if + port_to_next_index_diff) ^ (*next0);
+	xor += (*next0) ^ (*next1);
+	xor += (*next1) ^ (*next2);
+	xor += (*next2) ^ (*next3);
+
+	if (xor) {
+		/* packets tx ports are not same, check first feature for each mbuf
+		 * make sure next0 != 0 which is pkt_drop
+		 */
+		port0 = (*next0) - port_to_next_index_diff;
+		port1 = (*next1) - port_to_next_index_diff;
+		port2 = (*next2) - port_to_next_index_diff;
+		port3 = (*next3) - port_to_next_index_diff;
+		if (unlikely((*next0 >= port_to_next_index_diff) &&
+			     rte_graph_feature_data_first_feature_get(arc, port0,
+								      &d0->feature_data,
+								      next0))) {
+			/* update next0 from feature arc */
+			mbuf0->port = port0;
+		}
+
+		if (unlikely((*next1 >= port_to_next_index_diff) &&
+			     rte_graph_feature_data_first_feature_get(arc, port1,
+								      &d1->feature_data,
+								      next1))) {
+			mbuf1->port = port1;
+		}
+
+		if (unlikely((*next2 >= port_to_next_index_diff) &&
+			     rte_graph_feature_data_first_feature_get(arc, port2,
+								      &d2->feature_data,
+								      next2))) {
+			mbuf2->port = port2;
+		}
+
+		if (unlikely((*next3 >= port_to_next_index_diff) &&
+			     rte_graph_feature_data_first_feature_get(arc, port3,
+								      &d3->feature_data,
+								      next3))) {
+			mbuf3->port = port3;
+
+			*tx_if = port3;
+			*last_next_index = *next3;
+		}
+		*feature_data = d3->feature_data;
+	} else {
+		/* All packets are same as last tx port. Check if feature enabled
+		 * on last packet is valid or not. If invalid no need to
+		 * change any next[0-3]
+		 * Also check packet is not being sent to pkt_drop node
+		 */
+		if (unlikely(rte_graph_feature_data_is_valid(*feature_data) &&
+			     (*next0 != 0))) {
+			*next0 = *last_next_index;
+			*next1 = *last_next_index;
+			*next2 = *last_next_index;
+			*next3 = *last_next_index;
+
+			d0->feature_data = *feature_data;
+			d1->feature_data = *feature_data;
+			d2->feature_data = *feature_data;
+			d3->feature_data = *feature_data;
+
+			mbuf0->port = *tx_if;
+			mbuf1->port = *tx_if;
+			mbuf2->port = *tx_if;
+			mbuf3->port = *tx_if;
+		}
+	}
+}
+
+static __rte_always_inline uint16_t
+__ip4_rewrite_node_process(struct rte_graph *graph, struct rte_node *node,
+			   void **objs, uint16_t nb_objs,
+			   const int dyn, const int check_enabled_features,
+			   const int feat_dyn,
+			   struct rte_graph_feature_arc *out_feature_arc)
 {
 	struct rte_mbuf *mbuf0, *mbuf1, *mbuf2, *mbuf3, **pkts;
 	struct ip4_rewrite_nh_header *nh = ip4_rewrite_nm->nh;
-	const int dyn = IP4_REWRITE_NODE_PRIV1_OFF(node->ctx);
 	uint16_t next0, next1, next2, next3, next_index;
 	struct rte_ipv4_hdr *ip0, *ip1, *ip2, *ip3;
 	uint16_t n_left_from, held = 0, last_spec = 0;
+	rte_graph_feature_data_t feature_data;
+	uint16_t last_tx_if, last_next_index;
 	void *d0, *d1, *d2, *d3;
 	void **to_next, **from;
 	rte_xmm_t priv01;
@@ -56,6 +211,28 @@ ip4_rewrite_node_process(struct rte_graph *graph, struct rte_node *node,
 
 	for (i = 0; i < 4 && i < n_left_from; i++)
 		rte_prefetch0(pkts[i]);
+
+	if (check_enabled_features) {
+		rte_graph_feature_arc_prefetch(out_feature_arc);
+
+		last_tx_if = IP4_REWRITE_NODE_LAST_TX_IF(node->ctx);
+
+		/* If feature is enabled on last_tx_if, prefetch data
+		 * corresponding to first feature
+		 */
+		if (unlikely(rte_graph_feature_data_first_feature_get(out_feature_arc,
+								      last_tx_if,
+								      &feature_data,
+								      &last_next_index)))
+			rte_graph_feature_arc_feature_data_prefetch(out_feature_arc,
+								    feature_data);
+
+		/* Reset last_tx_if and last_next_index to call feature arc APIs
+		 * for initial packets in every node loop
+		 */
+		last_tx_if = UINT16_MAX;
+		last_next_index = UINT16_MAX;
+	}
 
 	/* Get stream for the speculated next node */
 	to_next = rte_node_next_stream_get(graph, node, next_index, nb_objs);
@@ -78,6 +255,7 @@ ip4_rewrite_node_process(struct rte_graph *graph, struct rte_node *node,
 
 		pkts += 4;
 		n_left_from -= 4;
+
 		priv01.u64[0] = node_mbuf_priv1(mbuf0, dyn)->u;
 		priv01.u64[1] = node_mbuf_priv1(mbuf1, dyn)->u;
 		priv23.u64[0] = node_mbuf_priv1(mbuf2, dyn)->u;
@@ -131,6 +309,16 @@ ip4_rewrite_node_process(struct rte_graph *graph, struct rte_node *node,
 					      sizeof(struct rte_ether_hdr));
 		ip3->time_to_live = priv23.u16[5] - 1;
 		ip3->hdr_checksum = priv23.u16[6] + priv23.u16[7];
+
+		/* Once all mbufs are updated with next hop data.
+		 * check if any feature is enabled to override
+		 * next edges
+		 */
+		if (check_enabled_features)
+			check_output_feature_arc_x4(out_feature_arc, &last_tx_if,
+						    mbuf0, mbuf1, mbuf2, mbuf3,
+						    &next0, &next1, &next2, &next3,
+						    &last_next_index, &feature_data, feat_dyn);
 
 		/* Enqueue four to next node */
 		rte_edge_t fix_spec =
@@ -225,6 +413,11 @@ ip4_rewrite_node_process(struct rte_graph *graph, struct rte_node *node,
 		ip0->hdr_checksum = chksum;
 		ip0->time_to_live = node_mbuf_priv1(mbuf0, dyn)->ttl - 1;
 
+		if (check_enabled_features)
+			check_output_feature_arc_x1(out_feature_arc, &last_tx_if,
+						    mbuf0, &next0, &last_next_index,
+						    &feature_data, feat_dyn);
+
 		if (unlikely(next_index ^ next0)) {
 			/* Copy things successfully speculated till now */
 			rte_memcpy(to_next, from, last_spec * sizeof(from[0]));
@@ -252,12 +445,50 @@ ip4_rewrite_node_process(struct rte_graph *graph, struct rte_node *node,
 	/* Save the last next used */
 	IP4_REWRITE_NODE_LAST_NEXT(node->ctx) = next_index;
 
+	if (check_enabled_features)
+		IP4_REWRITE_NODE_LAST_TX_IF(node->ctx) = last_tx_if;
+
 	return nb_objs;
 }
+
+static uint16_t
+ip4_rewrite_feature_node_process(struct rte_graph *graph, struct rte_node *node,
+				 void **objs, uint16_t nb_objs)
+{
+	struct rte_graph_feature_arc *arc = NULL;
+		rte_graph_feature_arc_get(IP4_REWRITE_NODE_OUTPUT_FEATURE_ARC(node->ctx));
+	const int feat_dyn = IP4_REWRITE_NODE_FEAT_OFF(node->ctx);
+	const int dyn = IP4_REWRITE_NODE_PRIV1_OFF(node->ctx);
+
+	arc = rte_graph_feature_arc_get(IP4_REWRITE_NODE_OUTPUT_FEATURE_ARC(node->ctx));
+	if (unlikely(rte_graph_feature_arc_is_any_feature_enabled(arc) &&
+		     (port_to_next_index_diff > 0)))
+		return __ip4_rewrite_node_process(graph, node, objs, nb_objs, dyn,
+						  1 /* check features */, feat_dyn, arc);
+
+	return __ip4_rewrite_node_process(graph, node, objs, nb_objs, dyn,
+					  0/* don't check features*/,
+					  feat_dyn /* don't care */,
+					  arc /* don't care*/);
+}
+
+static uint16_t
+ip4_rewrite_node_process(struct rte_graph *graph, struct rte_node *node,
+			 void **objs, uint16_t nb_objs)
+{
+	const int dyn = IP4_REWRITE_NODE_PRIV1_OFF(node->ctx);
+
+	return __ip4_rewrite_node_process(graph, node, objs, nb_objs, dyn,
+					  0/* don't check features*/,
+					  0 /* don't care */,
+					  NULL/* don't care */);
+}
+
 
 static int
 ip4_rewrite_node_init(const struct rte_graph *graph, struct rte_node *node)
 {
+	rte_graph_feature_arc_t feature_arc;
 	static bool init_once;
 
 	RTE_SET_USED(graph);
@@ -268,9 +499,27 @@ ip4_rewrite_node_init(const struct rte_graph *graph, struct rte_node *node)
 				&node_mbuf_priv1_dynfield_desc);
 		if (node_mbuf_priv1_dynfield_offset < 0)
 			return -rte_errno;
+
+		/* Create ipv4-output feature arc, if not created
+		 */
+		if (rte_graph_feature_arc_lookup_by_name(RTE_IP4_OUTPUT_FEATURE_ARC_NAME,
+						     &feature_arc) < 0) {
+			node_err("ip4_rewrite", "Feature arc \"%s\" not found",
+				 RTE_IP4_OUTPUT_FEATURE_ARC_NAME);
+		} else {
+			node_err("ip4_rewrite", "Feature arc \"%s\" found",
+				 RTE_IP4_OUTPUT_FEATURE_ARC_NAME);
+		}
+
 		init_once = true;
 	}
 	IP4_REWRITE_NODE_PRIV1_OFF(node->ctx) = node_mbuf_priv1_dynfield_offset;
+	IP4_REWRITE_NODE_FEAT_OFF(node->ctx) = rte_graph_feature_arc_mbuf_dynfield_offset_get();
+	IP4_REWRITE_NODE_OUTPUT_FEATURE_ARC(node->ctx) = feature_arc;
+
+	/* By default, set cached next node to pkt_drop */
+	IP4_REWRITE_NODE_LAST_NEXT(node->ctx) = 0;
+	IP4_REWRITE_NODE_LAST_TX_IF(node->ctx) = 0;
 
 	node_dbg("ip4_rewrite", "Initialized ip4_rewrite node initialized");
 
@@ -280,12 +529,18 @@ ip4_rewrite_node_init(const struct rte_graph *graph, struct rte_node *node)
 int
 ip4_rewrite_set_next(uint16_t port_id, uint16_t next_index)
 {
+	static int once;
+
 	if (ip4_rewrite_nm == NULL) {
 		ip4_rewrite_nm = rte_zmalloc(
 			"ip4_rewrite", sizeof(struct ip4_rewrite_node_main),
 			RTE_CACHE_LINE_SIZE);
 		if (ip4_rewrite_nm == NULL)
 			return -ENOMEM;
+	}
+	if (!once) {
+		port_to_next_index_diff = next_index - port_id;
+		once = 1;
 	}
 	ip4_rewrite_nm->next_index[port_id] = next_index;
 
@@ -345,3 +600,23 @@ ip4_rewrite_node_get(void)
 }
 
 RTE_NODE_REGISTER(ip4_rewrite_node);
+
+/* IP4 output arc */
+static struct rte_graph_feature_arc_register ip4_output_arc = {
+	.arc_name = RTE_IP4_OUTPUT_FEATURE_ARC_NAME,
+
+	/* This arc works on all ethdevs */
+	.max_indexes = RTE_IP4_OUTPUT_ARC_INDEXES,
+
+	.start_node = &ip4_rewrite_node,
+
+	/* overwrites start_node->process() function with following only if
+	 * application calls rte_graph_feature_arc_init()
+	 */
+	.start_node_feature_process_fn = ip4_rewrite_feature_node_process,
+
+	/* end feature node of an arc*/
+	.end_feature = &if_tx_feature,
+};
+
+RTE_GRAPH_FEATURE_ARC_REGISTER(ip4_output_arc);

--- a/lib/node/ip4_rewrite.c
+++ b/lib/node/ip4_rewrite.c
@@ -464,7 +464,7 @@ ip4_rewrite_feature_node_process(struct rte_graph *graph, struct rte_node *node,
 	if (unlikely(rte_graph_feature_arc_is_any_feature_enabled(arc) &&
 		     (port_to_next_index_diff > 0)))
 		return __ip4_rewrite_node_process(graph, node, objs, nb_objs, dyn,
-						  1 /* check features */, feat_dyn, arc);
+						  0 /* check features */, feat_dyn, arc);
 
 	return __ip4_rewrite_node_process(graph, node, objs, nb_objs, dyn,
 					  0/* don't check features*/,

--- a/lib/node/meson.build
+++ b/lib/node/meson.build
@@ -24,6 +24,7 @@ sources = files(
         'pkt_cls.c',
         'pkt_drop.c',
         'udp4_input.c',
+        'interface_tx_feature.c'
 )
 headers = files(
         'rte_node_eth_api.h',

--- a/lib/node/node_private.h
+++ b/lib/node/node_private.h
@@ -13,6 +13,7 @@
 #include <rte_mbuf_dyn.h>
 
 #include <rte_graph_worker_common.h>
+#include <rte_graph_feature_arc_worker.h>
 
 extern int rte_node_logtype;
 #define RTE_LOGTYPE_NODE rte_node_logtype

--- a/lib/node/rte_node_ip4_api.h
+++ b/lib/node/rte_node_ip4_api.h
@@ -24,6 +24,10 @@
 extern "C" {
 #endif
 
+/** IP4 output arc */
+#define RTE_IP4_OUTPUT_FEATURE_ARC_NAME "rte_ip4_output_arc"
+#define RTE_IP4_OUTPUT_END_FEATURE_NAME "rte_if_tx_feature"
+
 /**
  * IP4 lookup next nodes.
  */


### PR DESCRIPTION
With this patch series, intermediate nodes are added to feature nodes (registered via RTE_GRAPH_FEATURE_REGISTER()) as next_nodes such that original next_node is attached to 0th index of intermediate nodes. Also feature childs are also added as next_node of intermediate node.

Intermediate nodes would send packet to 0th index if no feature is enabled, if feature is enabled then next edge returned from arc APIs is used to send to correct next feature child

While feature node's process() function continue to send packets to original next_node(s)

Change-Id: I19181a229544f6b9d03a04f13a44a98c17b8fda9